### PR TITLE
Adding timing and other execution info to ActionResult

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -612,6 +612,12 @@ message ExecutedActionMetadata {
 
   // When the worker completed executing the action command.
   google.protobuf.Timestamp execution_completed_timestamp = 8;
+
+  // When the worker started uploading action outputs.
+  google.protobuf.Timestamp output_upload_start_timestamp = 9;
+
+  // When the worker finished uploading action outputs.
+  google.protobuf.Timestamp output_upload_completed_timestamp = 10;
 }
 
 // An ActionResult represents the result of an

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -19,6 +19,7 @@ package build.bazel.remote.execution.v2;
 import "google/api/annotations.proto";
 import "google/longrunning/operations.proto";
 import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
 
 option csharp_namespace = "Build.Bazel.Remote.Execution.V2";
@@ -586,6 +587,33 @@ message Digest {
   int64 size_bytes = 2;
 }
 
+// ExecutedActionMetadata contains details about a completed execution.
+message ExecutedActionMetadata {
+  // The name of the worker which ran the execution.
+  string worker = 1;
+
+  // When was the action added to the queue.
+  google.protobuf.Timestamp queued_timestamp = 2;
+
+  // When the worker received the action.
+  google.protobuf.Timestamp worker_start_timestamp = 3;
+
+  // When the worker completed the action, including all stages.
+  google.protobuf.Timestamp worker_completed_timestamp = 4;
+
+  // When the worker started fetching action inputs.
+  google.protobuf.Timestamp input_fetch_start_timestamp = 5;
+
+  // When the worker finished fetching action inputs.
+  google.protobuf.Timestamp input_fetch_completed_timestamp = 6;
+
+  // When the worker started executing the action command.
+  google.protobuf.Timestamp execution_start_timestamp = 7;
+
+  // When the worker completed executing the action command.
+  google.protobuf.Timestamp execution_completed_timestamp = 8;
+}
+
 // An ActionResult represents the result of an
 // [Action][build.bazel.remote.execution.v2.Action] being run.
 message ActionResult {
@@ -692,6 +720,9 @@ message ActionResult {
   // [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage].
   // See `stderr_raw` for when this will be set.
   Digest stderr_digest = 8;
+
+  // The details of the execution that originally produced this result.
+  ExecutedActionMetadata execution_metadata = 9;
 }
 
 // An `OutputFile` is similar to a


### PR DESCRIPTION
This change was originally proposed by Daniel Wagner-Hall. In the proposal, ActionResult will contain the metadata of the corresponding execution so that it is available on cached actions as well.