### PR TITLE
Add a working directory to the Action message.

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -426,6 +426,11 @@ message Command {
   // value, the environment variables MUST be lexicographically sorted by name.
   // Sorting of strings is done by code point, equivalently, by the UTF-8 bytes.
   repeated EnvironmentVariable environment_variables = 2;
+
+  // The working directory, relative to the input root, for the command to run
+  // in. It must be a directory which exists in the input tree. If it is left
+  // empty, then the action is run in the input root.
+  string working_directory = 6;
 }
 
 // A `Platform` is a set of requirements, such as hardware, operating system, or


### PR DESCRIPTION
This allows a job to be started from a directory other than the input
root. While Bazel does not need this functionality, it is not uncommon
for other build systems to descend into subdirectories to run their
actions, and forcing them to either re-architect so that they run from
input root or include a wrapper script is not optimal, especially given
that such wrappers are platform-dependent and, on platforms with high
process startup latency, may cost performance.