### PR TITLE
Adding Results Cache Policy To Execution Requests.

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -774,9 +774,10 @@ message ExecutionPolicy {
 // outputs are stored in the CAS and Action Cache.
 message ResultsCachePolicy {
   // The priority (relative importance) of this content in the overall cache.
-  // Generally, a higher value means a longer retention time or other advantage,
-  // but the interpretation of a given value is server-dependent. A priority of 0
-  // means a *default* value, decided by the server.
+  // Generally, a lower value means a longer retention time or other advantage,
+  // but the interpretation of a given value is server-dependent. A priority of
+  // 0 means a *default* value, decided by the server.
+  //
   // The particular semantics of this field is up to the server. In particular,
   // every server will have their own supported range of priorities, and will
   // decide how these map into retention/eviction policy.
@@ -932,6 +933,11 @@ message UpdateActionResultRequest {
   // The [ActionResult][build.bazel.remote.execution.v2.ActionResult]
   // to store in the cache.
   ActionResult action_result = 3;
+
+  // An optional policy for the results of this execution in the remote cache.
+  // The server will have a default policy if this is not provided.
+  // This may be applied to both the ActionResult and the associated blobs.
+  ResultsCachePolicy results_cache_policy = 4;
 }
 
 // A request message for

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -770,6 +770,19 @@ message ExecutionPolicy {
   int32 priority = 1;
 }
 
+// A `ResultsCachePolicy` is used for fine-grained control over how action
+// outputs are stored in the CAS and Action Cache.
+message ResultsCachePolicy {
+  // The priority (relative importance) of this content in the overall cache.
+  // Generally, a higher value means a longer retention time or other advantage,
+  // but the interpretation of a given value is server-dependent. A priority of 0
+  // means a *default* value, decided by the server.
+  // The particular semantics of this field is up to the server. In particular,
+  // every server will have their own supported range of priorities, and will
+  // decide how these map into retention/eviction policy.
+  int32 priority = 1;
+}
+
 // A request message for
 // [Execution.Execute][build.bazel.remote.execution.v2.Execution.Execute].
 message ExecuteRequest {
@@ -793,6 +806,11 @@ message ExecuteRequest {
   // An optional policy for execution of the action.
   // The server will have a default policy if this is not provided.
   ExecutionPolicy execution_policy = 6;
+
+  // An optional policy for the results of this execution in the remote cache.
+  // The server will have a default policy if this is not provided.
+  // This may be applied to both the ActionResult and the associated blobs.
+  ResultsCachePolicy results_cache_policy = 7;
 }
 
 // A `LogFile` is a log stored in the CAS.


### PR DESCRIPTION
Not all action results and CAS blobs are born equal. Some services will have overall space constraints, and throwing out CI execution results in favor of more recent developer build results would not be a good idea for overall performance. Meaning, some implementations may want to granulate cache policy on a per execution basis, and not just on a per-customer basis.

This value will be passed through Bazel via a flag, something like --remote_cache_priority=X, with a default value of 0. The particular value will only make sense for a given server, and even then, not all users may have permissions on setting high cache retention priority for their content.
If a user tries to set a value for which they don’t have permission, the server will return a PERMISSION_DENIED error.

We will soon add a section on a proposed Capabilities API, which will allow, among other things, to fetch the valid priority range from a server for a particular user programmatically.