### PR TITLE
Adding supported RE API versions to Server Capabilities

### DIFF
--- a/build/bazel/remote/execution/v2/BUILD
+++ b/build/bazel/remote/execution/v2/BUILD
@@ -6,6 +6,7 @@ proto_library(
     name = "remote_execution_proto",
     srcs = ["remote_execution.proto"],
     deps = [
+        "//build/bazel/semver:semver_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:timestamp_proto",
         "@googleapis//:google_api_annotations_proto",

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package build.bazel.remote.execution.v2;
 
+import "build/bazel/semver/semver.proto";
 import "google/api/annotations.proto";
 import "google/longrunning/operations.proto";
 import "google/protobuf/duration.proto";
@@ -1136,6 +1137,15 @@ message ServerCapabilities {
 
   // Capabilities of the remote execution system.
   ExecutionCapabilities execution_capabilities = 2;
+
+  // Earliest RE API version supported, including deprecated versions.
+  build.bazel.semver.SemVer deprecated_api_version = 3;
+
+  // Earliest non-deprecated RE API version supported.
+  build.bazel.semver.SemVer low_api_version = 4;
+
+  // Latest RE API version supported.
+  build.bazel.semver.SemVer high_api_version = 5;
 }
 
 // The digest function used for converting values into keys for CAS and Action

--- a/build/bazel/semver/BUILD
+++ b/build/bazel/semver/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+proto_library(
+    name = "semver_proto",
+    srcs = ["semver.proto"],
+)

--- a/build/bazel/semver/semver.proto
+++ b/build/bazel/semver/semver.proto
@@ -1,0 +1,24 @@
+// Copyright 2018 The Bazel Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package build.bazel.semver;
+
+message SemVer {
+  int32 major = 1;
+  int32 minor = 2;
+  int32 patch = 3;
+  string prerelease = 4;
+}


### PR DESCRIPTION
We want to report all the versions the server supports, as well as which ones are deprecated, so that the client can display warning/error messages.