### PR TITLE
Adding batch downloads method and minor naming tweaks.

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -248,12 +248,12 @@ service ContentAddressableStorage {
   // chunks or uploaded using the
   // [ByteStream API][google.bytestream.ByteStream], as appropriate.
   //
-  // This request is equivalent to calling a hypothetical `UpdateBlob` request
+  // This request is equivalent to calling a Bytestream `Write` request
   // on each individual blob, in parallel. The requests may succeed or fail
   // independently.
   //
   // Errors:
-  // * `INVALID_ARGUMENT`: The client attempted to upload more than 10 MiB of
+  // * `INVALID_ARGUMENT`: The client attempted to upload more than 4 MiB of
   //   data.
   //
   // Individual requests may return the following errors, additionally:
@@ -263,6 +263,27 @@ service ContentAddressableStorage {
   // provided data.
   rpc BatchUpdateBlobs(BatchUpdateBlobsRequest) returns (BatchUpdateBlobsResponse) {
     option (google.api.http) = { post: "/v2/{instance_name=**}/blobs:batchUpdate" body: "*" };
+  }
+
+  // Download many blobs at once.
+  //
+  // The client MUST NOT download blobs with a combined total size of more than 4
+  // MiB using this API. Such requests should either be split into smaller
+  // chunks or downloaded using the
+  // [ByteStream API][google.bytestream.ByteStream], as appropriate.
+  //
+  // This request is equivalent to calling a Bytestream `Read` request
+  // on each individual blob, in parallel. The requests may succeed or fail
+  // independently.
+  //
+  // Errors:
+  // * `INVALID_ARGUMENT`: The client attempted to read more than 4 MiB of
+  //   data.
+  //
+  // Every error on individual read will be returned in the corresponding digest
+  // status.
+  rpc BatchReadBlobs(BatchReadBlobsRequest) returns (BatchReadBlobsResponse) {
+    option (google.api.http) = { post: "/v2/{instance_name=**}/blobs:batchRead" body: "*" };
   }
 
   // Fetch the entire directory tree rooted at a node.
@@ -1037,19 +1058,18 @@ message FindMissingBlobsResponse {
   repeated Digest missing_blob_digests = 2;
 }
 
-// A single request message for
-// [ContentAddressableStorage.BatchUpdateBlobs][build.bazel.remote.execution.v2.ContentAddressableStorage.BatchUpdateBlobs].
-message UpdateBlobRequest {
-  // The digest of the blob. This MUST be the digest of `data`.
-  Digest content_digest = 1;
-
-  // The raw binary data.
-  bytes data = 2;
-}
-
 // A request message for
 // [ContentAddressableStorage.BatchUpdateBlobs][build.bazel.remote.execution.v2.ContentAddressableStorage.BatchUpdateBlobs].
 message BatchUpdateBlobsRequest {
+  // A request corresponding to a single blob that the client wants to upload.
+  message Request {
+    // The digest of the blob. This MUST be the digest of `data`.
+    Digest digest = 1;
+
+    // The raw binary data.
+    bytes data = 2;
+  }
+
   // The instance of the execution system to operate against. A server may
   // support multiple instances of the execution system (with their own workers,
   // storage, caches, etc.). The server MAY require use of this field to select
@@ -1058,7 +1078,7 @@ message BatchUpdateBlobsRequest {
   string instance_name = 1;
 
   // The individual upload requests.
-  repeated UpdateBlobRequest requests = 2;
+  repeated Request requests = 2;
 }
 
 // A response message for
@@ -1066,10 +1086,43 @@ message BatchUpdateBlobsRequest {
 message BatchUpdateBlobsResponse {
   // A response corresponding to a single blob that the client tried to upload.
   message Response {
-    // The digest to which this response corresponds.
-    Digest blob_digest = 1;
+    // The blob digest to which this response corresponds.
+    Digest digest = 1;
 
     // The result of attempting to upload that blob.
+    google.rpc.Status status = 2;
+  }
+
+  // The responses to the requests.
+  repeated Response responses = 1;
+}
+
+// A request message for
+// [ContentAddressableStorage.BatchReadBlobs][build.bazel.remote.execution.v2.ContentAddressableStorage.BatchReadBlobs].
+message BatchReadBlobsRequest {
+  // The instance of the execution system to operate against. A server may
+  // support multiple instances of the execution system (with their own workers,
+  // storage, caches, etc.). The server MAY require use of this field to select
+  // between them in an implementation-defined fashion, otherwise it can be
+  // omitted.
+  string instance_name = 1;
+
+  // The individual blob digests.
+  repeated Digest digests = 2;
+}
+
+// A response message for
+// [ContentAddressableStorage.BatchReadBlobs][build.bazel.remote.execution.v2.ContentAddressableStorage.BatchReadBlobs].
+message BatchReadBlobsResponse {
+  // A response corresponding to a single blob that the client tried to upload.
+  message Response {
+    // The digest to which this response corresponds.
+    Digest digest = 1;
+
+    // The raw binary data.
+    bytes data = 2;
+
+    // The result of attempting to download that blob.
     google.rpc.Status status = 2;
   }
 


### PR DESCRIPTION
@alercah did a performance analysis that showed significant improvement when batching is used for uploading small blobs. We suspect that batched downloads will have similar effect. This is primarily intended to be used by the bots, rather than clients, but could be used by the client as well.