### PR TITLE
Allowing file symlink outputs.

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -901,8 +901,7 @@ message OutputDirectory {
 
 // An `OutputSymlink` is similar to a
 // [Symlink][build.bazel.remote.execution.v2.SymlinkNode], but it is used as an
-// output in an `ActionResult`. It allows a full file path rather than
-// only a name. It is only used with symlinks pointing to files, not directories.
+// output in an `ActionResult`.
 //
 // `OutputSymlink` is binary-compatible with `SymlinkNode`.
 message OutputSymlink {

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -727,7 +727,7 @@ message ActionResult {
   // For each output file requested in the `output_files` field of the Action,
   // if the corresponding file existed after
   // the action completed, a single entry will be present either in this field,
-  // or in the output_files field, if the file was not a symbolic link.
+  // or in the `output_files` field, if the file was not a symbolic link.
   //
   // If the action does not produce the requested output, or produces a
   // directory where a regular file is expected or vice versa, then that output
@@ -795,6 +795,22 @@ message ActionResult {
   // }
   // ```
   repeated OutputDirectory output_directories = 3;
+
+  // The output directories of the action that are symbolic links to other
+  // directories. Those may be links to other output directories, or input
+  // directories, or even absolute paths outside of the working directory,
+  // if the server supports
+  // [SymlinkAbsolutePathStrategy.ALLOWED][build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy].
+  // For each output directory requested in the `output_directories` field of
+  // the Action, if the directory file existed after
+  // the action completed, a single entry will be present either in this field,
+  // or in the `output_directories` field, if the directory was not a symbolic link.
+  //
+  // If the action does not produce the requested output, or produces a
+  // file where a directory is expected or vice versa, then that output
+  // will be omitted from the list. The server is free to arrange the output
+  // list as desired; clients MUST NOT assume that the output list is sorted.
+  repeated OutputSymlink output_directory_symlinks = 11;
 
   // The exit code of the command.
   int32 exit_code = 4;

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -710,13 +710,30 @@ message ActionResult {
 
   // The output files of the action. For each output file requested in the
   // `output_files` field of the Action, if the corresponding file existed after
-  // the action completed, a single entry will be present in the output list.
+  // the action completed, a single entry will be present either in this field,
+  // or in the output_file_symlinks field, if the file was a symbolic link to
+  // another file.
   //
   // If the action does not produce the requested output, or produces a
   // directory where a regular file is expected or vice versa, then that output
   // will be omitted from the list. The server is free to arrange the output
   // list as desired; clients MUST NOT assume that the output list is sorted.
   repeated OutputFile output_files = 2;
+
+  // The output files of the action that are symbolic links to other files. Those
+  // may be links to other output files, or input files, or even absolute paths
+  // outside of the working directory, if the server supports
+  // [SymlinkAbsolutePathStrategy.ALLOWED][build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy].
+  // For each output file requested in the `output_files` field of the Action,
+  // if the corresponding file existed after
+  // the action completed, a single entry will be present either in this field,
+  // or in the output_files field, if the file was not a symbolic link.
+  //
+  // If the action does not produce the requested output, or produces a
+  // directory where a regular file is expected or vice versa, then that output
+  // will be omitted from the list. The server is free to arrange the output
+  // list as desired; clients MUST NOT assume that the output list is sorted.
+  repeated OutputSymlink output_file_symlinks = 10;
 
   // The output directories of the action. For each output directory requested
   // in the `output_directories` field of the Action, if the corresponding
@@ -864,6 +881,27 @@ message OutputDirectory {
   // [Tree][build.bazel.remote.execution.v2.Tree] proto containing the
   // directory's contents.
   Digest tree_digest = 3;
+}
+
+// An `OutputSymlink` is similar to a
+// [Symlink][build.bazel.remote.execution.v2.SymlinkNode], but it is used as an
+// output in an `ActionResult`. It allows a full file path rather than
+// only a name. It is only used with symlinks pointing to files, not directories.
+//
+// `OutputSymlink` is binary-compatible with `SymlinkNode`.
+message OutputSymlink {
+  // The full path of the symlink relative to the working directory, including the
+  // filename. The path separator is a forward slash `/`. Since this is a
+  // relative path, it MUST NOT begin with a leading forward slash.
+  string path = 1;
+
+  // The target path of the symlink. The path separator is a forward slash `/`.
+  // The target path can be relative to the parent directory of the symlink or
+  // it can be an absolute path starting with `/`. Support for absolute paths
+  // can be checked using the [Capabilities][build.bazel.remote.execution.v2.Capabilities]
+  // API. The canonical form forbids the substrings `/./` and `//` in the target
+  // path. `..` components are allowed anywhere in the target path.
+  string target = 2;
 }
 
 // An `ExecutionPolicy` can be used to control the scheduling of the action.


### PR DESCRIPTION
This is a missing case from the existing API: all symlinks that are part of larger
output directories are already supported. However, if the output
file or output directory is itself a symlink, then the current API does not distinguish that, and instead just provides the content Digest.

A motivating case for distinguishing the symlink case is efficiency,
when the client did not want the action to create and download a copy of
an existing file.

TESTED=bazel build

	modified:   build/bazel/remote/execution/v2/remote_execution.proto