### PR TITLE
Removing the no-parent restriction in output files and directories

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -438,9 +438,8 @@ message Command {
   // MUST be sorted lexicographically by code point (or, equivalently, by UTF-8
   // bytes).
   //
-  // An output file cannot be duplicated, be a parent of another output file, be
-  // a child of a listed output directory, or have the same path as any of the
-  // listed output directories.
+  // An output file cannot be duplicated, be a parent of another output file, or
+  // have the same path as any of the listed output directories.
   repeated string output_files = 3;
 
   // A list of the output directories that the client expects to retrieve from
@@ -461,9 +460,8 @@ message Command {
   // MUST be sorted lexicographically by code point (or, equivalently, by UTF-8
   // bytes).
   //
-  // An output directory cannot be duplicated, be a parent of another output
-  // directory, be a parent of a listed output file, or have the same path as
-  // any of the listed output files.
+  // An output directory cannot be duplicated or have the same path as any of
+  // the listed output files.
   repeated string output_directories = 4;
 
   // The platform requirements for the execution environment. The server MAY


### PR DESCRIPTION
Currently, the output files and directories of an action have the following restrictions:
- an output file cannot be a child of an output directory
- an output directory cannot be a child of another output directory

I propose to remove both these restrictions. Reasons:
- In Bazel, it is difficult to generate an output directory and both refer to the entire directory in child action A and refer only to a particular file out of that directory in a child action B. In fact, it's not possible -- the only workaround the situation would be to manually throw these cases out when we build the Command proto.
- This complicates code unnecessarily on both clients and servers! Example of client code complication (in addition to above): it's very hard to check whether an Action produced all the required outputs with the restriction in place. We have to go inside the output directories (and follow symlinks!) to make sure a particular output file or child directory was present -- instead of simply checking in the ActionResult itself.