### PR TITLE
Clarify semantics of CancelOperation

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -93,6 +93,9 @@ service Execution {
   // * `INTERNAL`: An internal error occurred in the execution engine or the
   //   worker.
   // * `DEADLINE_EXCEEDED`: The execution timed out.
+  // * `CANCELLED`: The operation was cancelled by the client. This status is
+  //   only possible if the server implements the Operations API CancelOperation
+  //   method, and it was called for the current execution.
   //
   // In the case of a missing input or command, the server SHOULD additionally
   // send a [PreconditionFailure][google.rpc.PreconditionFailure] error detail


### PR DESCRIPTION
The Operations API specifies the use of the error field on the Operation proto in case the operation was cancelled. However, for our API, we want to remove all uses of this field, and use the ExecuteResponse.status instead. Therefore, we need to explicitly specify what should happen in case the server implements CancelOperation (which it doesn't have to!) and it was called for the given exeution.