### PR TITLE
Add an additional_info_url fields to ExecuteResponse.

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -1027,6 +1027,10 @@ message ExecuteResponse {
   // phase. The keys SHOULD be human readable so that a client can display them
   // to a user.
   map<string, LogFile> server_logs = 4;
+
+  // Freeform informational message with details on the execution of the action
+  // that may be displayed to the user upon failure or when requested explicitly.
+  string message = 5;
 }
 
 // Metadata about an ongoing


### PR DESCRIPTION
As mentioned in https://github.com/bazelbuild/bazel/pull/6591, Bazel
Buildbarn now ships with a web service that can be used to explore data
stored in the CAS and AC.

By adding an extra field to ExecuteResponse, we can let Bazel
automatically report URLs to the user pointing to the correct page.
These URLs could, for example, be printed for build steps that fail.