### PR TITLE
Document that parent directories of outputs are created implicitly.

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -444,6 +444,9 @@ message Command {
   //
   // An output file cannot be duplicated, be a parent of another output file, or
   // have the same path as any of the listed output directories.
+  //
+  // Directories leading up to the output files are created by the worker prior
+  // to execution, even if they are not explicitly part of the input root.
   repeated string output_files = 3;
 
   // A list of the output directories that the client expects to retrieve from
@@ -468,6 +471,10 @@ message Command {
   //
   // An output directory cannot be duplicated or have the same path as any of
   // the listed output files.
+  //
+  // Directories leading up to the output directories (but not the output
+  // directories themselves) are created by the worker prior to execution, even
+  // if they are not explicitly part of the input root.
   repeated string output_directories = 4;
 
   // The platform requirements for the execution environment. The server MAY


### PR DESCRIPTION
When implementing Buildbarn's worker, I noticed that there exists the
assumption in build rules that directories under bazel-out/ are already
created prior to execution, even if they are not part of the input root.

As I suspect that getting rid of this assumption is both unrealistic and
undesirable, let's document this instead.

Mentioned in: #40