### PR TITLE
Document what the intended file permissions of the input root is.

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -382,7 +382,7 @@ message Action {
   // by the build action at any place within the input root.
   //
   // In addition to that, the entire input root must be exposed through
-  // a single mount, meaning that calls to the rename() on files and
+  // a single mount, meaning that calls to rename() on files and
   // directories within the input root may not fail due to cross-device
   // links. If the operating system executing the build action supports
   // hard links, the same applies to link(). Whether directories outside

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -385,12 +385,15 @@ message Action {
   // a single mount, meaning that calls to the rename() on files and
   // directories within the input root may not fail due to cross-device
   // links. If the operating system executing the build action supports
-  // hard links, the same applies to link().
+  // hard links, the same applies to link(). Whether directories outside
+  // of the input root (e.g., /tmp) reside on the same file system is
+  // unspecified.
   //
   // Due to recent versions of Linux disallowing the creation of hard
   // links to files without having write access to them (sysctl
-  // fs.protected_hardlinks=1), the build action may only be permitted
-  // to create hard links to files that were not part of the input root.
+  // fs.protected_hardlinks=1) and input files may not be writable, the
+  // build action may only be permitted to create hard links to files in
+  // the input root that were created at runtime.
   Digest input_root_digest = 2;
 
   reserved 3 to 5; // Used for fields moved to [Command][build.bazel.remote.execution.v2.Command].

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -379,7 +379,7 @@ message Action {
   // input root are available for reading (i.e., at least 'r--' or 'r-x'
   // in terms of UNIX permissions). All directories are available for
   // writing ('rwx'), meaning that files and directories may be created
-  // by the build action at any place within the input root.
+  // and deleted by the build action at any place within the input root.
   //
   // In addition to that, the entire input root must be exposed through
   // a single mount, meaning that calls to rename() on files and

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -374,6 +374,23 @@ message Action {
   // directory, as well as every subdirectory and content blob referred to, MUST
   // be in the
   // [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage].
+  //
+  // The build action may assume that all files that are part of the
+  // input root are available for reading (i.e., at least 'r--' or 'r-x'
+  // in terms of UNIX permissions). All directories are available for
+  // writing ('rwx'), meaning that files and directories may be created
+  // by the build action at any place within the input root.
+  //
+  // In addition to that, the entire input root must be exposed through
+  // a single mount, meaning that calls to the rename() on files and
+  // directories within the input root may not fail due to cross-device
+  // links. If the operating system executing the build action supports
+  // hard links, the same applies to link().
+  //
+  // Due to recent versions of Linux disallowing the creation of hard
+  // links to files without having write access to them (sysctl
+  // fs.protected_hardlinks=1), the build action may only be permitted
+  // to create hard links to files that were not part of the input root.
   Digest input_root_digest = 2;
 
   reserved 3 to 5; // Used for fields moved to [Command][build.bazel.remote.execution.v2.Command].


### PR DESCRIPTION
At the build event at Bloomberg, several users of REv2 (Bazel,
Buildbarn, BuildGrid) discussed what file permissions of the input root
ought to be. Basically, there were two camps:

- Camp A: reduce the number of writable files and directories to the
  absolute minumum (Bazel and Buildbarn).

- Camp B: keep files read-only to allow caching based on hardlinks,
  while making all directories writable (BuildGrid). This is desired to
  support the execution of very large build actions that invoke
  traditional build systems that tend to clobber the input root all over
  the place.

It was eventually decided to support the latter. In the long run a
separate effort could be started to lock this down further, if it turns
out this causes significant performance overhead.

Until recently, Buildbarn also followed the second approach. A recent
change caused Buildbarn to only make directories with one or more
outputs to be writable and all of the parent directories. This change
will be reverted to match the semantics proposed by this commit.

Fixes: #43