### PR TITLE
Clarify semantics around do_not_cache and skip_cache_lookup

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -396,7 +396,8 @@ message Action {
   // immediately, rather than whenever the cache entry gets evicted.
   google.protobuf.Duration timeout = 6;
 
-  // If true, then the `Action`'s result cannot be cached.
+  // If true, then the `Action`'s result cannot be cached, and in-flight
+  // requests for the same `Action` may not be merged.
   bool do_not_cache = 7;
 }
 
@@ -982,9 +983,19 @@ message ExecuteRequest {
   // omitted.
   string instance_name = 1;
 
-  // If true, the action will be executed anew even if its result was already
-  // present in the cache. If false, the result may be served from the
-  // [ActionCache][build.bazel.remote.execution.v2.ActionCache].
+  // If true, the action will be executed even if its result is already
+  // present in the [ActionCache][build.bazel.remote.execution.v2.ActionCache].
+  // The execution is still allowed to be merged with other in-flight executions
+  // of the same action, however - semantically, the service MUST only guarantee
+  // that the results of an execution with this field set were not visible
+  // before the corresponding execution request was sent.
+  // Note that actions from execution requests setting this field set are still
+  // eligible to be entered into the action cache upon completion, and services
+  // SHOULD overwrite any existing entries that may exist. This allows
+  // skip_cache_lookup requests to be used as a mechanism for replacing action
+  // cache entries that reference outputs no longer available or that are
+  // poisoned in any way.
+  // If false, the result may be served from the action cache.
   bool skip_cache_lookup = 3;
 
   reserved 2, 4, 5; // Used for removed fields in an earlier version of the API.


### PR DESCRIPTION
Clarify semantics for do_not_cache and skip_cache_lookup fields to cover the semantics of when in-flight actions may be "merged", and to clarify when results are and aren't eligible for caching.

The use-cases of interest I'm considering are:
  - Minimizing total number of executions for idempotent actions. (The default: neither field is set; only one total execution is required)
 - Bypassing and overwriting the Action Cache when its results are stale or corrupt. (skip_cache_lookup should be set and the result should still be cached).
 - Actions with side-effects that should always be re-executed (do_not_cache should be set, multiple in-flight requests should not be merged)
 - Actions intentionally being (re)run, e.g. for performance analysis across multiple attempts. (do_not_cache should be set; multiple in-flight requests should not be merged).

I took a look at Bazel and I believe its usage to be consistent with these semantics:
 - --runs_per_test implies uncacheable: https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java#L373
 - Outputs found to be missing after an action cache entry is found result in re-execution with skip_cache_lookup set so the action gets re-executed: https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java#L209

Any sanity-checks that the comments here are clear and understandable would be great, and/or validation that this is consistent with the semantics expected by other client tools.