### PR TITLE
support inlining of output files in the action result

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -738,8 +738,8 @@ message ActionResult {
   // The output files of the action. For each output file requested in the
   // `output_files` field of the Action, if the corresponding file existed after
   // the action completed, a single entry will be present either in this field,
-  // or the `inlined_output_files` field or the `output_file_symlinks` field if the
-  // file was a symbolic link to another file.
+  // or the `output_file_symlinks` field if the file was a symbolic link to
+  // another file.
   //
   // If the action does not produce the requested output, or produces a
   // directory where a regular file is expected or vice versa, then that output
@@ -845,7 +845,8 @@ message ActionResult {
   // The standard output buffer of the action. The server SHOULD NOT inline
   // stdout unless requested by the client in the
   // [GetActionResultRequest][build.bazel.remote.execution.v2.GetActionResultRequest]
-  // message.
+  // message. The server MAY omit inlining, even if requested, and MUST do so if inlining
+  // would cause the response to exceed message size limits.
   bytes stdout_raw = 5;
 
   // The digest for a blob containing the standard output of the action, which
@@ -856,7 +857,8 @@ message ActionResult {
   // The standard error buffer of the action. The server SHOULD NOT inline
   // stderr unless requested by the client in the
   // [GetActionResultRequest][build.bazel.remote.execution.v2.GetActionResultRequest]
-  // message.
+  // message. The server MAY omit inlining, even if requested, and MUST do so if inlining
+  // would cause the response to exceed message size limits.
   bytes stderr_raw = 7;
 
   // The digest for a blob containing the standard error of the action, which
@@ -889,6 +891,8 @@ message OutputFile {
   // The contents of the file if inlining was requested. The server SHOULD NOT inline
   // file contents unless requested by the client in the
   // [GetActionResultRequest][build.bazel.remote.execution.v2.GetActionResultRequest]
+  // message. The server MAY omit inlining, even if requested, and MUST do so if inlining
+  // would cause the response to exceed message size limits.
   bytes contents = 5;
 }
 

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -845,8 +845,7 @@ message ActionResult {
   // The standard output buffer of the action. The server SHOULD NOT inline
   // stdout unless requested by the client in the
   // [GetActionResultRequest][build.bazel.remote.execution.v2.GetActionResultRequest]
-  // message and instead return a digest in `stdout_digest` that points to
-  // the buffer.
+  // message.
   bytes stdout_raw = 5;
 
   // The digest for a blob containing the standard output of the action, which
@@ -857,8 +856,7 @@ message ActionResult {
   // The standard error buffer of the action. The server SHOULD NOT inline
   // stderr unless requested by the client in the
   // [GetActionResultRequest][build.bazel.remote.execution.v2.GetActionResultRequest]
-  // message and instead return a digest in `stderr_digest` that points to
-  // the buffer.
+  // message.
   bytes stderr_raw = 7;
 
   // The digest for a blob containing the standard error of the action, which

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -732,10 +732,6 @@ message ExecutedActionMetadata {
 
 // An ActionResult represents the result of an
 // [Action][build.bazel.remote.execution.v2.Action] being run.
-//
-// The server MUST NOT make any inlining decisions on his own but should
-// do so when requested by the client. The total serialized message size
-// SHOULD NOT exceed 1 MiB.
 message ActionResult {
   reserved 1; // Reserved for use as the resource name.
 
@@ -750,12 +746,6 @@ message ActionResult {
   // will be omitted from the list. The server is free to arrange the output
   // list as desired; clients MUST NOT assume that the output list is sorted.
   repeated OutputFile output_files = 2;
-
-  // The output files of the action whose contents are inlined into the request.
-  // A server MUST NOT inline outputs unless requested by the client in the
-  // [GetActionResultRequest][build.bazel.remote.execution.v2.GetActionResultRequest]
-  // message.
-  repeated InlinedOutputFile inlined_output_files = 12;
 
   // The output files of the action that are symbolic links to other files. Those
   // may be links to other output files, or input files, or even absolute paths
@@ -852,34 +842,28 @@ message ActionResult {
   // The exit code of the command.
   int32 exit_code = 4;
 
-  // The standard output buffer of the action. The server MUST NOT inline
+  // The standard output buffer of the action. The server SHOULD NOT inline
   // stdout unless requested by the client in the
   // [GetActionResultRequest][build.bazel.remote.execution.v2.GetActionResultRequest]
   // message and instead return a digest in `stdout_digest` that points to
-  // the buffer. The client SHOULD NOT assume it will get one of the raw
-  // buffer or a digest on any given request and should be prepared to handle
-  // either.
+  // the buffer.
   bytes stdout_raw = 5;
 
   // The digest for a blob containing the standard output of the action, which
   // can be retrieved from the
   // [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage].
-  // See `stdout_raw` for when this will be set.
   Digest stdout_digest = 6;
 
-  // The standard error buffer of the action. The server MUST NOT inline
+  // The standard error buffer of the action. The server SHOULD NOT inline
   // stderr unless requested by the client in the
   // [GetActionResultRequest][build.bazel.remote.execution.v2.GetActionResultRequest]
   // message and instead return a digest in `stderr_digest` that points to
-  // the buffer. The client SHOULD NOT assume it will get one of the raw
-  // buffer or a digest on any given request and should be prepared to handle
-  // either.
+  // the buffer.
   bytes stderr_raw = 7;
 
   // The digest for a blob containing the standard error of the action, which
   // can be retrieved from the
   // [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage].
-  // See `stderr_raw` for when this will be set.
   Digest stderr_digest = 8;
 
   // The details of the execution that originally produced this result.
@@ -890,8 +874,6 @@ message ActionResult {
 // [FileNode][build.bazel.remote.execution.v2.FileNode], but it is used as an
 // output in an `ActionResult`. It allows a full file path rather than
 // only a name.
-//
-// `OutputFile` is binary-compatible with `FileNode`.
 message OutputFile {
   // The full path of the file relative to the working directory, including the
   // filename. The path separator is a forward slash `/`. Since this is a
@@ -905,24 +887,11 @@ message OutputFile {
 
   // True if file is executable, false otherwise.
   bool is_executable = 4;
-}
 
-// `InlinedOutputFile` is similar to [OutputFile][build.bazel.remote.execution.v2.OutputFile]
-// but has its contents inlined in the message.
-message InlinedOutputFile {
-  // The full path of the file relative to the working directory, including the
-  // filename. The path separator is a forward slash `/`. Since this is a
-  // relative path, it MUST NOT begin with a leading forward slash.
-  string path = 1;
-
-  // The contents of the file.
-  bytes contents = 2;
-
-  // The digest of the file's content.
-  Digest digest = 3;
-
-  // True if file is executable, false otherwise.
-  bool is_executable = 4;
+  // The contents of the file if inlining was requested. The server SHOULD NOT inline
+  // file contents unless requested by the client in the
+  // [GetActionResultRequest][build.bazel.remote.execution.v2.GetActionResultRequest]
+  bytes contents = 5;
 }
 
 // A `Tree` contains all the
@@ -1158,11 +1127,11 @@ message GetActionResultRequest {
   // whose result is requested.
   Digest action_digest = 2;
 
-  // A hint to the server to inline stdout in the
+  // A hint to the server to request inlining stdout in the
   // [ActionResult][build.bazel.remote.execution.v2.ActionResult] message.
   bool inline_stdout = 3;
 
-  // A hint to the server to inline stderr in the
+  // A hint to the server to request inlining stderr in the
   // [ActionResult][build.bazel.remote.execution.v2.ActionResult] message.
   bool inline_stderr = 4;
 

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -732,20 +732,30 @@ message ExecutedActionMetadata {
 
 // An ActionResult represents the result of an
 // [Action][build.bazel.remote.execution.v2.Action] being run.
+//
+// The server MUST NOT make any inlining decisions on his own but should
+// do so when requested by the client. The total serialized message size
+// SHOULD NOT exceed 1 MiB.
 message ActionResult {
   reserved 1; // Reserved for use as the resource name.
 
   // The output files of the action. For each output file requested in the
   // `output_files` field of the Action, if the corresponding file existed after
   // the action completed, a single entry will be present either in this field,
-  // or in the output_file_symlinks field, if the file was a symbolic link to
-  // another file.
+  // or the `inlined_output_files` field or the `output_file_symlinks` field if the
+  // file was a symbolic link to another file.
   //
   // If the action does not produce the requested output, or produces a
   // directory where a regular file is expected or vice versa, then that output
   // will be omitted from the list. The server is free to arrange the output
   // list as desired; clients MUST NOT assume that the output list is sorted.
   repeated OutputFile output_files = 2;
+
+  // The output files of the action whose contents are inlined into the request.
+  // A server MUST NOT inline outputs unless requested by the client in the
+  // [GetActionResultRequest][build.bazel.remote.execution.v2.GetActionResultRequest]
+  // message.
+  repeated InlinedOutputFile inlined_output_files = 12;
 
   // The output files of the action that are symbolic links to other files. Those
   // may be links to other output files, or input files, or even absolute paths
@@ -842,12 +852,13 @@ message ActionResult {
   // The exit code of the command.
   int32 exit_code = 4;
 
-  // The standard output buffer of the action. The server will determine, based
-  // on the size of the buffer, whether to return it in raw form or to return
-  // a digest in `stdout_digest` that points to the buffer. If neither is set,
-  // then the buffer is empty. The client SHOULD NOT assume it will get one of
-  // the raw buffer or a digest on any given request and should be prepared to
-  // handle either.
+  // The standard output buffer of the action. The server MUST NOT inline
+  // stdout unless requested by the client in the
+  // [GetActionResultRequest][build.bazel.remote.execution.v2.GetActionResultRequest]
+  // message and instead return a digest in `stdout_digest` that points to
+  // the buffer. The client SHOULD NOT assume it will get one of the raw
+  // buffer or a digest on any given request and should be prepared to handle
+  // either.
   bytes stdout_raw = 5;
 
   // The digest for a blob containing the standard output of the action, which
@@ -856,12 +867,13 @@ message ActionResult {
   // See `stdout_raw` for when this will be set.
   Digest stdout_digest = 6;
 
-  // The standard error buffer of the action. The server will determine, based
-  // on the size of the buffer, whether to return it in raw form or to return
-  // a digest in `stderr_digest` that points to the buffer. If neither is set,
-  // then the buffer is empty. The client SHOULD NOT assume it will get one of
-  // the raw buffer or a digest on any given request and should be prepared to
-  // handle either.
+  // The standard error buffer of the action. The server MUST NOT inline
+  // stderr unless requested by the client in the
+  // [GetActionResultRequest][build.bazel.remote.execution.v2.GetActionResultRequest]
+  // message and instead return a digest in `stderr_digest` that points to
+  // the buffer. The client SHOULD NOT assume it will get one of the raw
+  // buffer or a digest on any given request and should be prepared to handle
+  // either.
   bytes stderr_raw = 7;
 
   // The digest for a blob containing the standard error of the action, which
@@ -890,6 +902,24 @@ message OutputFile {
   Digest digest = 2;
 
   reserved 3; // Used for a removed field in an earlier version of the API.
+
+  // True if file is executable, false otherwise.
+  bool is_executable = 4;
+}
+
+// `InlinedOutputFile` is similar to [OutputFile][build.bazel.remote.execution.v2.OutputFile]
+// but has its contents inlined in the message.
+message InlinedOutputFile {
+  // The full path of the file relative to the working directory, including the
+  // filename. The path separator is a forward slash `/`. Since this is a
+  // relative path, it MUST NOT begin with a leading forward slash.
+  string path = 1;
+
+  // The contents of the file.
+  bytes contents = 2;
+
+  // The digest of the file's content.
+  Digest digest = 3;
 
   // True if file is executable, false otherwise.
   bool is_executable = 4;
@@ -1127,6 +1157,19 @@ message GetActionResultRequest {
   // The digest of the [Action][build.bazel.remote.execution.v2.Action]
   // whose result is requested.
   Digest action_digest = 2;
+
+  // A hint to the server to inline stdout in the
+  // [ActionResult][build.bazel.remote.execution.v2.ActionResult] message.
+  bool inline_stdout = 3;
+
+  // A hint to the server to inline stderr in the
+  // [ActionResult][build.bazel.remote.execution.v2.ActionResult] message.
+  bool inline_stderr = 4;
+
+  // A hint to the server to inline the contents of the listed output files.
+  // Each path needs to exactly match one path in `output_files` in the
+  // [Command][build.bazel.remote.execution.v2.Command] message.
+  repeated string inline_output_files = 5;
 }
 
 // A request message for


### PR DESCRIPTION
Allow the client to request the inlining of action outputs,
stdout and stderr in the action result message. We only add
this capability to the GetActionResult call for now as its
typically on the latency sensitive fast path, while Execute
is not.

Also make the stdout and stderr inlining decisions client
controlled and recommend for the server to keep the serialized
size of the ActionResult message below 1 MiB [1].

See https://groups.google.com/d/msg/remote-execution-apis/bmUuI2wUcwA/p0yrYq7VBgAJ

[1] https://developers.google.com/protocol-buffers/docs/techniques#large-data