### PR TITLE
Upgrade version of gRPC used to latest tag since 0.17.1 doesn't work with Bazel 0.25.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,12 +33,12 @@ http_archive(
 # Needed for C++ gRPC.
 http_archive(
     name = "com_github_grpc_grpc",
-    strip_prefix = "grpc-1.17.2",
+    strip_prefix = "grpc-1.20.1",
     urls = [
-        "https://github.com/grpc/grpc/archive/v1.17.2.tar.gz",
-        "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.17.2.tar.gz",
+        "https://github.com/grpc/grpc/archive/v1.20.1.tar.gz",
+        "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.20.1.tar.gz",
     ],
-    sha256 = "34ed95b727e7c6fcbf85e5eb422e962788e21707b712fdb4caf931553c2c6dbc",
+    sha256 = "ba8b08a697b66e14af35da07753583cf32ff3d14dcd768f91b1bbe2e6c07c349",
 )
 
 # Pull in all gRPC dependencies.


### PR DESCRIPTION
Here's the error I was getting, which is resolved with this upgrade:

$ bazel build build/bazel/remote/execution/v2:remote_execution_java_proto
ERROR: Skipping 'build/bazel/remote/execution/v2:remote_java_proto': error loading package 'build/bazel/remote/execution/v2': in <REDACTED>/external/com_github_grpc_grpc/bazel/cc_grpc_library.bzl: Label '@com_github_grpc_grpc//:bazel/generate_cc.bzl' crosses boundary of subpackage '@com_github_grpc_grpc//bazel' (perhaps you meant to put the colon here: '@com_github_grpc_grpc//bazel:generate_cc.bzl'?)