### PR TITLE
Clarify outputs must match stated types

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -478,7 +478,8 @@ message Command {
   // bytes).
   //
   // An output directory cannot be duplicated or have the same path as any of
-  // the listed output files.
+  // the listed output files. An output directory is allowed to be a parent of
+  // another output directory.
   //
   // Directories leading up to the output directories (but not the output
   // directories themselves) are created by the worker prior to execution, even
@@ -740,8 +741,9 @@ message ActionResult {
   // or in the output_file_symlinks field, if the file was a symbolic link to
   // another file.
   //
-  // If the action does not produce the requested output, or produces a
-  // directory where a regular file is expected or vice versa, then that output
+  // If an output of the same name was found, but was a directory rather
+  // than a regular file, the server will return a FAILED_PRECONDITION.
+  // If the action does not produce the requested output, then that output
   // will be omitted from the list. The server is free to arrange the output
   // list as desired; clients MUST NOT assume that the output list is sorted.
   repeated OutputFile output_files = 2;
@@ -755,8 +757,9 @@ message ActionResult {
   // the action completed, a single entry will be present either in this field,
   // or in the `output_files` field, if the file was not a symbolic link.
   //
-  // If the action does not produce the requested output, or produces a
-  // directory where a regular file is expected or vice versa, then that output
+  // If an output symbolic link of the same name was found, but its target
+  // type was not a regular file, the server will return a FAILED_PRECONDITION.
+  // If the action does not produce the requested output, then that output
   // will be omitted from the list. The server is free to arrange the output
   // list as desired; clients MUST NOT assume that the output list is sorted.
   repeated OutputSymlink output_file_symlinks = 10;
@@ -820,6 +823,8 @@ message ActionResult {
   //   }
   // }
   // ```
+  // If an output of the same name was found, but was not a directory, the
+  // server will return a FAILED_PRECONDITION.
   repeated OutputDirectory output_directories = 3;
 
   // The output directories of the action that are symbolic links to other
@@ -828,12 +833,13 @@ message ActionResult {
   // if the server supports
   // [SymlinkAbsolutePathStrategy.ALLOWED][build.bazel.remote.execution.v2.CacheCapabilities.SymlinkAbsolutePathStrategy].
   // For each output directory requested in the `output_directories` field of
-  // the Action, if the directory file existed after
-  // the action completed, a single entry will be present either in this field,
-  // or in the `output_directories` field, if the directory was not a symbolic link.
+  // the Action, if the directory existed after the action completed, a
+  // single entry will be present either in this field, or in the
+  // `output_directories` field, if the directory was not a symbolic link.
   //
-  // If the action does not produce the requested output, or produces a
-  // file where a directory is expected or vice versa, then that output
+  // If an output of the same name was found, but was a symbolic link to a file
+  // instead of a directory, the server will return a FAILED_PRECONDITION.
+  // If the action does not produce the requested output, then that output
   // will be omitted from the list. The server is free to arrange the output
   // list as desired; clients MUST NOT assume that the output list is sorted.
   repeated OutputSymlink output_directory_symlinks = 11;


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/remote-apis/issues/63