### PR TITLE
Add an option for using the Microsoft VSO-Hash digest function

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -1349,6 +1349,10 @@ enum DigestFunction {
 
   // The MD5 digest function.
   MD5 = 3;
+
+  // The Microsoft "VSO-Hash" paged SHA256 digest function.
+  // See https://github.com/microsoft/BuildXL/blob/master/Documentation/Specs/PagedHash.md .
+  VSO = 4;
 }
 
 // Describes the server/instance capabilities for updating the action cache.


### PR DESCRIPTION
This allows Remote Exec implementations for Microsoft Build Accelerator (https://github.com/Microsoft/BuildXL) to exchange its standard hashes