### PR TITLE
Update io_bazel_rules_go to release 0.18.6

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,8 +78,11 @@ http_archive(
 # Pull in go rules.
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "86ae934bd4c43b99893fc64be9d9fc684b81461581df7ea8fc291c816f5ee8c5",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.3/rules_go-0.18.3.tar.gz"],
+    urls = [
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
+    ],
+    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
 )
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
 go_rules_dependencies()


### PR DESCRIPTION
pre-commit hook builds using bazel release 0.28.1 with the updated go rules: https://github.com/bazelbuild/rules_go/releases/tag/0.18.6

closes #92 