### PR TITLE
Remove disabled rule log

### DIFF
--- a/repository_rules.bzl
+++ b/repository_rules.bzl
@@ -9,7 +9,7 @@ https://github.com/googleapis/googleapis/blob/master/repository_rules.bzl
 def _switched_rules_impl(ctx):
     disabled_rule_script = """
 def {rule_name}(**kwargs):
-    print("Ignoring {rule_name}(name = %s)" % kwargs.get("name",  None))
+    pass
 """
     enabled_native_rule_script = """
 {rule_name} = {native_rule_name}


### PR DESCRIPTION
Since there is no way to differentiate between a debug log and a normal
log, this adds noise to the build that you can do nothing about, so this
removes it.