### PR TITLE
point out that servers may modify ActionResults, and mention one reason why

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -161,6 +161,9 @@ service ActionCache {
   // [Command][build.bazel.remote.execution.v2.Command], into the
   // `ContentAddressableStorage`.
   //
+  // Server implementations MAY modify the
+  // `UpdateActionResultRequest.action_result` and return an equivalent value.
+  //
   // Errors:
   //
   // * `INVALID_ARGUMENT`: One or more arguments are invalid.
@@ -853,6 +856,11 @@ message ExecutedActionMetadata {
 
 // An ActionResult represents the result of an
 // [Action][build.bazel.remote.execution.v2.Action] being run.
+//
+// It is advised that at least one field (for example
+// `ActionResult.execution_metadata.Worker`) have a non-default value, to
+// ensure that the serialized value is non-empty, which can then be used
+// as a basic data sanity check.
 message ActionResult {
   reserved 1; // Reserved for use as the resource name.
 


### PR DESCRIPTION
When serialized, default ActionResult proto3 messages contain no data. This is unfortunate because there is no way to distinguish this valid data from from file truncation errors on the server (which are perhaps the most common form of file-based data corruption).

As a workaround, server implementations can modify incoming ActionResult messages to ensure that at least one field has a non-default value, and then consider any default/zero-length ActionResult messages retrieved from storage as corrupt. Let's point this out in the documentation.

The simplest field that servers may consider modifying is ActionResult.execution_metadata.worker, which (if empty) can safely be set to the IP address or hostname of the creator/uploader without modifying the semantic meaning of the ActionResult.