### PR TITLE
Clarify that servers should extend TLL for blobs referenced in FindMissingBlobs

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -246,6 +246,9 @@ service ContentAddressableStorage {
   // Clients can use this API before uploading blobs to determine which ones are
   // already present in the CAS and do not need to be uploaded again.
   //
+  // Servers SHOULD increase the TTLs of the referenced blobs if necessary and
+  // applicable.
+  //
   // There are no method-specific errors.
   rpc FindMissingBlobs(FindMissingBlobsRequest) returns (FindMissingBlobsResponse) {
     option (google.api.http) = { post: "/v2/{instance_name=**}/blobs:findMissing" body: "*" };


### PR DESCRIPTION
* build/bazel/remote/execution/v2/remote_execution.proto 
  (ContentAddressableStorage.FindMissingBlobs): Clarify that servers
  should extend lifetime for blobs requested.