### PR TITLE
use ASCII apostrophes in remote_asset.proto

### DIFF
--- a/build/bazel/remote/asset/v1/remote_asset.proto
+++ b/build/bazel/remote/asset/v1/remote_asset.proto
@@ -36,18 +36,18 @@ option objc_class_prefix = "RA";
 // same tarball may exist at multiple mirrors and thus be retrievable from
 // multiple URLs.  When URLs are used, these should refer to actual content as
 // Fetch service implementations may choose to fetch the content directly
-// from the origin.  For example, the HEAD of a git repository’s active branch
+// from the origin.  For example, the HEAD of a git repository's active branch
 // can be referred to as:
 //
 //     uri: https://github.com/bazelbuild/remote-apis.git
 //
 // URNs may be used to strongly identify content, for instance by using the
 // uuid namespace identifier: urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6.
-// This is most applicable to named content that is Push’d, where the URN
+// This is most applicable to named content that is Push'd, where the URN
 // serves as an agreed-upon key, but carries no other inherent meaning.
 //
 // Service implementations may choose to support only URLs, only URNs for
-// Push’d content, only other URIs for which the server and client agree upon
+// Push'd content, only other URIs for which the server and client agree upon
 // semantics of, or any mixture of the above.
 
 // Qualifiers are used to disambiguate or sub-select content that shares a URI.
@@ -66,7 +66,7 @@ option objc_class_prefix = "RA";
 // Qualifiers may be supplied in any order.
 message Qualifier {
   // The “name” of the qualifier, for example “resource_type”.
-  // No separation is made between ‘standard’ and ‘nonstandard’
+  // No separation is made between ‘standard' and ‘nonstandard'
   // qualifiers, in accordance with https://tools.ietf.org/html/rfc6648,
   // however implementers *SHOULD* take care to avoid ambiguity.
   string name = 1;
@@ -106,8 +106,8 @@ service Fetch {
   // API and allow content to be directly inserted for use in future fetch
   // responses.
   //
-  // Servers *MUST* ensure Fetch’d content matches all the specified
-  // qualifiers except in the case of previously Push’d resources, for which
+  // Servers *MUST* ensure Fetch'd content matches all the specified
+  // qualifiers except in the case of previously Push'd resources, for which
   // the server *MAY* trust the pushing client to have set the qualifiers
   // correctly, without validation.
   //
@@ -121,7 +121,7 @@ service Fetch {
   // might be passed through `git-archive`.
   //
   // Errors handling the requested assets will be returned as gRPC Status errors
-  // here; errors outside the server’s control will be returned inline in the
+  // here; errors outside the server's control will be returned inline in the
   // `status` field of the response (see comment there for details).
   // The possible RPC errors include:
   // * `INVALID_ARGUMENT`: One or more arguments were invalid, such as a
@@ -230,7 +230,7 @@ message FetchBlobResponse {
   google.protobuf.Timestamp expires_at = 4;
 
   // The result of the fetch, if the status had code `OK`.
-  // The digest of the file’s contents, available for download through the CAS.
+  // The digest of the file's contents, available for download through the CAS.
   build.bazel.remote.execution.v2.Digest blob_digest = 5;
 }
 
@@ -342,10 +342,10 @@ service Push {
   // Clients can specify expiration information that the server *SHOULD*
   // respect. Subsequent requests can be used to alter the expiration time.
   //
-  // A minimal compliant Fetch implementation may support only Push’d content
+  // A minimal compliant Fetch implementation may support only Push'd content
   // and return `NOT_FOUND` for any resource that was not pushed first.
   // Alternatively, a compliant implementation may choose to not support Push
-  // and only return resources that can be Fetch’d from origin.
+  // and only return resources that can be Fetch'd from origin.
   //
   // Errors will be returned as gRPC Status errors.
   // The possible RPC errors include:


### PR DESCRIPTION
IIRC someone reported that unicode apostrophes break some software?