### PR TITLE
Specify that stderr and stdout streams are resource names

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -1224,14 +1224,14 @@ message ExecuteOperationMetadata {
   // being executed.
   Digest action_digest = 2;
 
-  // If set, the client can use this name with
+  // If set, the client can use this resource name with
   // [ByteStream.Read][google.bytestream.ByteStream.Read] to stream the
-  // standard output.
+  // standard output from the endpoint hosting streamed responses.
   string stdout_stream_name = 3;
 
-  // If set, the client can use this name with
+  // If set, the client can use this resource name with
   // [ByteStream.Read][google.bytestream.ByteStream.Read] to stream the
-  // standard error.
+  // standard error from the endpoint hosting streamed responses.
   string stderr_stream_name = 4;
 }
 


### PR DESCRIPTION
In lieu of a more fully fledged service discovery layer, explicitly specify that the stderr and stdout stream names are in fact URIs from which one can Bytestream.Read.