### PR TITLE
be consistent with regards to emphasis

### DIFF
--- a/build/bazel/remote/asset/v1/remote_asset.proto
+++ b/build/bazel/remote/asset/v1/remote_asset.proto
@@ -114,7 +114,7 @@ service Fetch {
   // Servers not implementing the complementary [Push][build.bazel.remote.asset.v1.Push]
   // API *MUST* reject requests containing qualifiers it does not support.
   //
-  // Servers **MAY** transform assets as part of the fetch. For example a
+  // Servers *MAY* transform assets as part of the fetch. For example a
   // tarball fetched by [FetchDirectory][build.bazel.remote.asset.v1.Fetch.FetchDirectory]
   // might be unpacked, or a Git repository
   // fetched by [FetchBlob][build.bazel.remote.asset.v1.Fetch.FetchBlob]


### PR DESCRIPTION
All other instances are `*MAY*` rather than `**MAY**`.