### PR TITLE
Use @bazel_remote_apis in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ rules.
 For instance, if you only use Java in your project, add the following to your
 `WORKSPACE` file:
 
-```
-load("@remoteapis//:repository_rules.bzl", "switched_rules_by_language")
+```starlark
+load("@bazel_remote_apis//:repository_rules.bzl", "switched_rules_by_language")
 switched_rules_by_language(
     name = "bazel_remote_apis_imports",
     java = True,


### PR DESCRIPTION
That's what is used in WORKSPACE, so it should also be used in the readme.