### PR TITLE
List EngFlow as another implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ These applications implement the Remote Execution API to server build requests
 from the clients above. These are then distributed to workers; some of these 
 workers implement the Remote Worker API.
 
-* [Buildbarn](https://github.com/buildbarn)
-* [Buildfarm](https://github.com/bazelbuild/bazel-buildfarm)
-* [BuildGrid](https://buildgrid.build/)
-* [Remote Build Execution (Alpha)](https://blog.bazel.build/2018/10/05/remote-build-execution.html)
-* [Scoot](https://github.com/twitter/scoot)
+* [Buildbarn](https://github.com/buildbarn) (open source)
+* [Buildfarm](https://github.com/bazelbuild/bazel-buildfarm) (open source)
+* [BuildGrid](https://buildgrid.build/) (open source)
+* [EngFlow](https://www.engflow.com/) (commercial)
+* [Remote Build Execution (Alpha)](https://blog.bazel.build/2018/10/05/remote-build-execution.html) (commercial)
+* [Scoot](https://github.com/twitter/scoot) (open source)
 
 ## API Community
 


### PR DESCRIPTION
Also clearly mark which ones are open source, and which are commercial ones.

If you can't accept this for policy reasons, I'd strongly recommend clarifying the policy around which implementations are listed here and also *being transparent* in the documentation that this is the case.