### PR TITLE
Servers must provide empty blobs that weren't uploaded

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -236,6 +236,10 @@ service ActionCache {
 // used in subsequent calls (e.g. to
 // [Execute][build.bazel.remote.execution.v2.Execution.Execute]).
 //
+// Servers MUST behave as though empty blobs are always available, even if they
+// have not been uploaded. Clients MAY optimize away the uploading or
+// downloading of empty blobs.
+//
 // As with other services in the Remote Execution API, any call may return an
 // error with a [RetryInfo][google.rpc.RetryInfo] error detail providing
 // information about when the client should retry the request; clients SHOULD


### PR DESCRIPTION
Some clients refer to empty blobs without previously uploading them, as a performance optimization. Servers must support this.