### PR TITLE
Drop canonicalization requirement for symlink targets

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -772,8 +772,11 @@ message SymlinkNode {
   // The target path can be relative to the parent directory of the symlink or
   // it can be an absolute path starting with `/`. Support for absolute paths
   // can be checked using the [Capabilities][build.bazel.remote.execution.v2.Capabilities]
-  // API. The canonical form forbids the substrings `/./` and `//` in the target
-  // path. `..` components are allowed anywhere in the target path.
+  // API. `..` components are allowed anywhere in the target path as logical
+  // canonicalization may lead to different behavior in the presence of
+  // directory symlinks (e.g. `foo/../bar` may not be the same as `bar`).
+  // To reduce potential cache misses, canonicalization is still recommended
+  // where this is possible without impacting correctness.
   string target = 2;
 
   // The node properties of the SymlinkNode.
@@ -1104,8 +1107,7 @@ message OutputSymlink {
   // The target path can be relative to the parent directory of the symlink or
   // it can be an absolute path starting with `/`. Support for absolute paths
   // can be checked using the [Capabilities][build.bazel.remote.execution.v2.Capabilities]
-  // API. The canonical form forbids the substrings `/./` and `//` in the target
-  // path. `..` components are allowed anywhere in the target path.
+  // API. `..` components are allowed anywhere in the target path.
   string target = 2;
 
   // The supported node properties of the OutputSymlink, if requested by the


### PR DESCRIPTION
This allows use of symlink targets created on the filesystem by existing
build tools and build systems without an extra REAPI-specific
canonicalization step.

The same build tool/system is still expected to create identical symlink
targets when executing the same Action again. I.e., this should not
result in different digests for logically equivalent Actions in common
cases.

As servers may but are not required to reject non-canonical input trees,
removing this canonicalization requirement for symlink targets reduces
the allowed differences in behavior between server implementations,
potentially improving interoperability.