### PR TITLE
Standardize the terminology on lifetime instead of TTL

### DIFF
--- a/build/bazel/remote/asset/v1/remote_asset.proto
+++ b/build/bazel/remote/asset/v1/remote_asset.proto
@@ -92,7 +92,7 @@ service Fetch {
   //
   // Servers *SHOULD* ensure that referenced files are present in the CAS at the
   // time of the response, and (if supported) that they will remain available
-  // for a reasonable period of time. The TTLs of the referenced blobs *SHOULD*
+  // for a reasonable period of time. The lifetimes of the referenced blobs *SHOULD*
   // be increased if necessary and applicable.
   // In the event that a client receives a reference to content that is no
   // longer present, it *MAY* re-issue the request with

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -142,7 +142,7 @@ service ActionCache {
   // [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage]
   // are available at the time of returning the
   // [ActionResult][build.bazel.remote.execution.v2.ActionResult] and will be
-  // for some period of time afterwards. The TTLs of the referenced blobs SHOULD be increased
+  // for some period of time afterwards. The lifetimes of the referenced blobs SHOULD be increased
   // if necessary and applicable.
   //
   // Errors:
@@ -254,7 +254,7 @@ service ContentAddressableStorage {
   // Clients can use this API before uploading blobs to determine which ones are
   // already present in the CAS and do not need to be uploaded again.
   //
-  // Servers SHOULD increase the TTLs of the referenced blobs if necessary and
+  // Servers SHOULD increase the lifetimes of the referenced blobs if necessary and
   // applicable.
   //
   // There are no method-specific errors.


### PR DESCRIPTION
Just a follow-up from a conversation https://github.com/bazelbuild/remote-apis/pull/113/files#r369491598
It seems that consensus is on using `lifetime` instead of `TTL` everywhere.