### PR TITLE
ExecutedActionMetadata: Allow adding auxiliary metadata

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -19,6 +19,7 @@ package build.bazel.remote.execution.v2;
 import "build/bazel/semver/semver.proto";
 import "google/api/annotations.proto";
 import "google/longrunning/operations.proto";
+import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
@@ -855,6 +856,11 @@ message ExecutedActionMetadata {
 
   // When the worker finished uploading action outputs.
   google.protobuf.Timestamp output_upload_completed_timestamp = 10;
+
+  // Details that are specific to the kind of worker used. For example,
+  // on POSIX-like systems this could contain a message with
+  // getrusage(2) statistics.
+  repeated google.protobuf.Any auxiliary_metadata = 11;
 }
 
 // An ActionResult represents the result of an


### PR DESCRIPTION
ExecutedActionMetadata provides a number of fields that help us to get insight in the worker that executed a build action, such as the name of the worker and some basic timing statistics.

Buildbarn ships with a small local modification to ExecutedActionMetadata, adding a 'repeated google.protobuf.Any' field. This field is used by some of Buildbarn's components to embed even more metrics into ActionResult, such as POSIX getrusage(2) information and temporary space allocation stats:

https://github.com/buildbarn/bb-remote-execution/blob/master/pkg/proto/resourceusage/resourceusage.proto

By having this data embedded in the ActionResult, people can view this information by simply inspecting a build action through bb-browser. This makes it easier for people to diagnose build failures accurately.

By using google.protobuf.Any, build clusters can expose their own metrics without requiring any further protocol extensions. It doesn't make sense to standardise those metrics, as they tend to be strongly implementation specific.