### PR TITLE
include comments in generated *.pb.go for godoc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+# Include comments in generated code for godoc.
+build --experimental_proto_descriptor_sets_include_source_info

--- a/build/bazel/remote/execution/v2/remote_execution.pb.go
+++ b/build/bazel/remote/execution/v2/remote_execution.pb.go
@@ -2362,7 +2362,8 @@ type GetActionResultRequest struct {
 	// [ActionResult][build.bazel.remote.execution.v2.ActionResult] message.
 	InlineStderr bool `protobuf:"varint,4,opt,name=inline_stderr,json=inlineStderr,proto3" json:"inline_stderr,omitempty"`
 	// A hint to the server to inline the contents of the listed output files.
-	// Each path needs to exactly match one path in `output_files` in the
+	// Each path needs to exactly match one file path in either `output_paths` or
+	// `output_files` (DEPRECATED since v2.1) in the
 	// [Command][build.bazel.remote.execution.v2.Command] message.
 	InlineOutputFiles    []string `protobuf:"bytes,5,rep,name=inline_output_files,json=inlineOutputFiles,proto3" json:"inline_output_files,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/build/bazel/semver/semver.pb.go
+++ b/build/bazel/semver/semver.pb.go
@@ -20,10 +20,17 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
+// The full version of a given tool.
 type SemVer struct {
-	Major                int32    `protobuf:"varint,1,opt,name=major,proto3" json:"major,omitempty"`
-	Minor                int32    `protobuf:"varint,2,opt,name=minor,proto3" json:"minor,omitempty"`
-	Patch                int32    `protobuf:"varint,3,opt,name=patch,proto3" json:"patch,omitempty"`
+	// The major version, e.g 10 for 10.2.3.
+	Major int32 `protobuf:"varint,1,opt,name=major,proto3" json:"major,omitempty"`
+	// The minor version, e.g. 2 for 10.2.3.
+	Minor int32 `protobuf:"varint,2,opt,name=minor,proto3" json:"minor,omitempty"`
+	// The patch version, e.g 3 for 10.2.3.
+	Patch int32 `protobuf:"varint,3,opt,name=patch,proto3" json:"patch,omitempty"`
+	// The pre-release version. Either this field or major/minor/patch fields
+	// must be filled. They are mutually exclusive. Pre-release versions are
+	// assumed to be earlier than any released versions.
 	Prerelease           string   `protobuf:"bytes,4,opt,name=prerelease,proto3" json:"prerelease,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`


### PR DESCRIPTION
It is very useful if [godoc](https://pkg.go.dev/github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2?tab=doc) includes comments propagated from proto files.

For that, this PR uses bazel's experimental flag introduced in https://github.com/bazelbuild/bazel/pull/10925

Fix #107