### PR TITLE
Add a clarification comment about the empty std*_digest

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -1021,6 +1021,7 @@ message ActionResult {
   // The digest for a blob containing the standard output of the action, which
   // can be retrieved from the
   // [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage].
+  // When ommited, MUST be treated as the digest of the empty blob.
   Digest stdout_digest = 6;
 
   // The standard error buffer of the action. The server SHOULD NOT inline
@@ -1033,6 +1034,7 @@ message ActionResult {
   // The digest for a blob containing the standard error of the action, which
   // can be retrieved from the
   // [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage].
+  // When ommited, MUST be treated as the digest of the empty blob. 
   Digest stderr_digest = 8;
 
   // The details of the execution that originally produced this result.


### PR DESCRIPTION
Bazel source code suggests that there should not be any difference in the client behavior between omitted `stdout_digest` and digest that points to an empty blob.

https://github.com/bazelbuild/bazel/blob/39bc97eab295bddb35b38bfc4a2ff3d2b15d034e/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java#L490

Same for the `stderr_digest`.
This change tries to codify this into the API.