### PR TITLE
[ci] autogenerate go bindings on master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Configure git
+      run: |
+        git config user.name "GitHub Actions Bot"
+        git config user.email "<>"
+
+    - name: Install bazelisk
+      run: |
+        curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.6.0/bazelisk-linux-amd64"
+        mkdir -p "${HOME}/bin"
+        mv bazelisk-linux-amd64 "${HOME}/bin/bazel"
+        chmod +x "${HOME}/bin/bazel"
+
+    - name: Run hooks
+      run: |
+        env
+        PATH=${HOME}/bin:$PATH ./hooks/pre-commit
+
+    - name: Check for changes
+      run: |
+        if ! git commit -m "regenerate pb.go files"
+        then
+          exit
+        fi
+        git push origin master


### PR DESCRIPTION
This is a github action which attempts to keep the generated *.pb.go code in sync with the corresponding .proto files on master. This action runs when master is updated- it takes a few minutes to run and will push a new commit to master if there were any changes required.

I assume if there are more than one of these actions running at the same time and both try to push, only the first will succeed. We should try to avoid this situation by not landing changes until the previous action has completed.

Possible (temporary?) solution to #162.