### PR TITLE
flag expr_proto_desc_sets unrecognized in few versions of bazel

### DIFF
--- a/build/bazel/remote/asset/v1/BUILD
+++ b/build/bazel/remote/asset/v1/BUILD
@@ -43,7 +43,8 @@ go_proto_library(
     importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1",
     proto = ":remote_asset_proto",
     deps = [
-        "//build/bazel/remote/execution/v2:go_default_library",
+        "//build/bazel/remote/execution/v2:remote_execution_go_proto",
+        "//build/bazel/semver:semver_go_proto",
         "@go_googleapis//google/api:annotations_go_proto",
         "@go_googleapis//google/rpc:status_go_proto",
     ],

--- a/build/bazel/remote/execution/v2/BUILD
+++ b/build/bazel/remote/execution/v2/BUILD
@@ -46,7 +46,7 @@ go_proto_library(
     importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2",
     proto = ":remote_execution_proto",
     deps = [
-        "//build/bazel/semver:go_default_library",
+        "//build/bazel/semver:semver_go_proto",
         "@go_googleapis//google/api:annotations_go_proto",
         "@go_googleapis//google/longrunning:longrunning_go_proto",
         "@go_googleapis//google/rpc:status_go_proto",

--- a/build/bazel/remote/execution/v2/remote_execution.pb.go
+++ b/build/bazel/remote/execution/v2/remote_execution.pb.go
@@ -613,6 +613,11 @@ func (m *Platform) GetProperties() []*Platform_Property {
 // The server MAY use the `value` of one or more properties to determine how
 // it sets up the execution environment, such as by making specific system
 // files available to the worker.
+//
+// Both names and values are typically case-sensitive. Note that the platform
+// is implicitly part of the action digest, so even tiny changes in the names
+// or values (like changing case) may result in different action cache
+// entries.
 type Platform_Property struct {
 	// The property name.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`


### PR DESCRIPTION
the flag isn't supported in few versions of Bazel, which leads to the following issue while trying to import and use `go_proto_library` targets from the repo. 
```
$ bazel build @bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_go_proto
ERROR: /home/basav/.cache/bazel/_bazel_basav/<>/external/bazel_remote_apis/build/bazel/remote/execution/v2/BUILD:43:1: GoCompilePkg external/bazel_remote_apis/build/bazel/remote/execution/v2/linux_amd64_stripped/remote_execution_go_proto%/github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2.a failed (Exit 1) builder failed: error executing command bazel-out/host/bin/external/go_sdk/builder compilepkg -sdk external/go_sdk -installsuffix linux_amd64 -src ... (remaining 51 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
compilepkg: missing strict dependencies:
	/home/basav/.cache/bazel/_bazel_basav/<>/sandbox/processwrapper-sandbox/767/execroot/<>/bazel-out/k8-fastbuild/bin/external/bazel_remote_apis/build/bazel/remote/execution/v2/linux_amd64_stripped/remote_execution_go_proto%/github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2/remote_execution.pb.go: import of "build/bazel/semver"
No dependencies were provided.
Check that imports in Go sources match importpath attributes in deps.
Target @bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_go_proto failed to build
```

Bazel Version: `1.0.0`