### PR TITLE
Add riscv ISA values to the Platform Lexicon document.

### DIFF
--- a/build/bazel/remote/execution/v2/platform.md
+++ b/build/bazel/remote/execution/v2/platform.md
@@ -35,6 +35,8 @@ The following standard property `name`s are defined:
     - `arm-t32-be` (big endian)
     - `power-isa-be` (big endian)
     - `power-isa-le` (little endian)
+    - `riscv32`
+    - `riscv64`
     - `sparc-v9` (big endian)
     - `x86-32`
     - `x86-64`


### PR DESCRIPTION
This adds the following values to the ISA list in platform.md
 - riscv32
 - riscv64

GCC, Linux and LLVM seem to agree on these names so this ought to be all that's needed.