### PR TITLE
Document that Execute() is permitted to run actions more than once

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -105,6 +105,11 @@ service Execution {
   // where, for each requested blob not present in the CAS, there is a
   // `Violation` with a `type` of `MISSING` and a `subject` of
   // `"blobs/{hash}/{size}"` indicating the digest of the missing blob.
+  //
+  // The server does not need to guarantee that a call to this method leads to
+  // at most one execution of the action. The server MAY execute the action
+  // multiple times, potentially in parallel. These redundant executions MAY
+  // continue to run, even if the operation is completed.
   rpc Execute(ExecuteRequest) returns (stream google.longrunning.Operation) {
     option (google.api.http) = { post: "/v2/{instance_name=**}/actions:execute" body: "*" };
   }


### PR DESCRIPTION
As discussed during yesterday's Remote Execution API Working Group
meeting, there may be cases in which it's desirable to run actions more
than once. For example, a cluster could first try to run the action on a
small worker, falling back to a larger worker in case of failure.

Let's make it explicit that the Execute() call doesn't guarantee that an
action is only run once. This makes it clear that the Remote Execution
protocol isn't suitable for running tasks that aren't idempotent.