### PR TITLE
Update output_paths to be relative to input root.

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -606,7 +606,7 @@ message Command {
   // Other files or directories that may be created during command execution
   // are discarded.
   //
-  // The paths are relative to the working directory of the action execution.
+  // The paths are relative to the input root of the action execution.
   // The paths are specified using a single forward slash (`/`) as a path
   // separator, even if the execution platform natively uses a different
   // separator. The path MUST NOT include a trailing slash, nor a leading slash,
@@ -651,6 +651,17 @@ message Command {
   // property is not recognized by the server, the server will return an
   // `INVALID_ARGUMENT`.
   repeated string output_node_properties = 8;
+
+  // True if the server should interpret output_paths as being relative to the
+  // input root. False if the server should interpret output_paths as being
+  // relative to the working directory. This is intended to provide a migration
+  // path from the old (working_directory) to the new (input root) semantics for
+  // output paths; eventually this field will be deprecated and ignored by the
+  // server.
+  //
+  // Note that this field does NOT affect the semantics of the output_files and
+  // output_directories fields.
+  bool input_root_relative_output_paths = 9;
 }
 
 // A `Platform` is a set of requirements, such as hardware, operating system, or


### PR DESCRIPTION
This is a prospective change based on conversation at the monthly sync. We know that

1) The current spec is quite clear about output_paths being working directory-relative.
2) Making output_paths relative to the working directory was probably a mistake. Making it relative to the input root leads to clearer semantics overall.
3) Currently some implementations (correctly) implement to the spec, and others implement input root-relative semantics.
4) Changing from one semantic to the other without breaking users is difficult, especially without a visible switch in the API.

The default assumption should be that the out-of-spec implementations should be updated, but given the general opinion that the spec is suboptimal, we floated the idea of updating the spec, which would cause other implementations to have to update.

As you comment on this PR, please note if possible whether you are commenting on the idea "in abstract" or from the perspective of a particular implementation.
