### PR TITLE
Fix incorrect protobuf spec

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -238,9 +238,6 @@ service ActionCache {
 //   the uploaded data once uncompressed, and MUST return an
 //   `INVALID_ARGUMENT` error in the case of mismatch.
 //
-// Note that when writing compressed blobs, the `WriteRequest.write_offset`
-// refers to the offset in the uncompressed form of the blob.
-//
 // Uploads of the same data MAY occur concurrently in any form, compressed or
 // uncompressed.
 //


### PR DESCRIPTION
The CAS compression spec currently states that WriteRequest.write_offset
is the offset in the uncompressed blob, but it does not match Google's
implementation on the client or server side.

The original intention was to encode each chunk, but having the entire
stream compressed seems better also because it allows the
reading-from-data-source-eg-disk and writing-to-CAS to happen
concurrently.