### PR TITLE
Clarify `WriteRequest.write_offset` spec for compressed blobs

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -243,6 +243,9 @@ service ActionCache {
 // blob. In subsequent requests, `WriteRequest.write_offset` MUST be the sum of
 // the previous `WriteRequest.write_offset` and the size of the compressed chunk
 // in the previous request.
+// Note that this mixes an uncompressed offset with a compressed byte length,
+// which is nonsensical, but it is done to fit the semantics of the existing
+// ByteStream protocol. This might be improved in the next version.
 //
 // Uploads of the same data MAY occur concurrently in any form, compressed or
 // uncompressed.

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -241,8 +241,8 @@ service ActionCache {
 // Note that when writing compressed blobs, the `WriteRequest.write_offset` in
 // the initial request refers to the offset in the uncompressed form of the
 // blob. In subsequent requests, `WriteRequest.write_offset` MUST be the sum of
-// previous `WriteRequest.write_offset` and the size of the chunk in the
-// previous request.
+// previous `WriteRequest.write_offset` and the size of the compressed chunk in
+// the previous request.
 //
 // Uploads of the same data MAY occur concurrently in any form, compressed or
 // uncompressed.

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -238,9 +238,6 @@ service ActionCache {
 //   the uploaded data once uncompressed, and MUST return an
 //   `INVALID_ARGUMENT` error in the case of mismatch.
 //
-// Note that when writing compressed blobs, the `WriteRequest.write_offset`
-// refers to the offset in the uncompressed form of the blob.
-//
 // Uploads of the same data MAY occur concurrently in any form, compressed or
 // uncompressed.
 //

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -239,10 +239,10 @@ service ActionCache {
 //   `INVALID_ARGUMENT` error in the case of mismatch.
 //
 // Note that when writing compressed blobs, the `WriteRequest.write_offset` in
-// the initial request refers to the offset in the uncompressed form of the
-// blob. In subsequent requests, `WriteRequest.write_offset` MUST be the sum of
-// the first request's 'WriteRequest.write_offset' and the total size of all the
-// compressed data bundles in the previous requests.
+// the initial request in a stream refers to the offset in the uncompressed form
+// of the blob. In subsequent requests, `WriteRequest.write_offset` MUST be the
+// sum of the first request's 'WriteRequest.write_offset' and the total size of
+// all the compressed data bundles in the previous requests.
 // Note that this mixes an uncompressed offset with a compressed byte length,
 // which is nonsensical, but it is done to fit the semantics of the existing
 // ByteStream protocol. This might be improved in the next version.

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -238,6 +238,12 @@ service ActionCache {
 //   the uploaded data once uncompressed, and MUST return an
 //   `INVALID_ARGUMENT` error in the case of mismatch.
 //
+// Note that when writing compressed blobs, the `WriteRequest.write_offset` in
+// the initial request refers to the offset in the uncompressed form of the
+// blob. In subsequent requests, `WriteRequest.write_offset` MUST be the sum of
+// previous `WriteRequest.write_offset` and the size of the chunk in the
+// previous request.
+//
 // Uploads of the same data MAY occur concurrently in any form, compressed or
 // uncompressed.
 //

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -241,8 +241,8 @@ service ActionCache {
 // Note that when writing compressed blobs, the `WriteRequest.write_offset` in
 // the initial request refers to the offset in the uncompressed form of the
 // blob. In subsequent requests, `WriteRequest.write_offset` MUST be the sum of
-// the previous `WriteRequest.write_offset` and the size of the compressed chunk
-// in the previous request.
+// the first request's 'WriteRequest.write_offset' and the total size of all the
+// compressed data bundles in the previous requests.
 // Note that this mixes an uncompressed offset with a compressed byte length,
 // which is nonsensical, but it is done to fit the semantics of the existing
 // ByteStream protocol. This might be improved in the next version.

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -245,7 +245,7 @@ service ActionCache {
 // all the compressed data bundles in the previous requests.
 // Note that this mixes an uncompressed offset with a compressed byte length,
 // which is nonsensical, but it is done to fit the semantics of the existing
-// ByteStream protocol. This might be improved in the next version.
+// ByteStream protocol.
 //
 // Uploads of the same data MAY occur concurrently in any form, compressed or
 // uncompressed.

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -241,8 +241,8 @@ service ActionCache {
 // Note that when writing compressed blobs, the `WriteRequest.write_offset` in
 // the initial request refers to the offset in the uncompressed form of the
 // blob. In subsequent requests, `WriteRequest.write_offset` MUST be the sum of
-// previous `WriteRequest.write_offset` and the size of the compressed chunk in
-// the previous request.
+// the previous `WriteRequest.write_offset` and the size of the compressed chunk
+// in the previous request.
 //
 // Uploads of the same data MAY occur concurrently in any form, compressed or
 // uncompressed.


### PR DESCRIPTION
The CAS compression spec currently states that WriteRequest.write_offset
is the offset in the uncompressed blob, but it does not match Google's
implementation on the client or server side.

The original intention was to encode each chunk, but having the entire
stream compressed seems better also because it allows the
reading-from-data-source-eg-disk and writing-to-CAS to happen
concurrently.