### PR TITLE
Document that ExecutionStages don't always transition forward

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -1338,7 +1338,7 @@ message ExecuteResponse {
 // Even though these stages are numbered according to the order in which
 // they generally occur, there is no requirement that the remote
 // execution system reports events along this order. For example, an
-// operation MAY to transition from the EXECUTING stage back to QUEUED
+// operation MAY transition from the EXECUTING stage back to QUEUED
 // in case the hardware on which the operation executes fails.
 //
 // If and only if the remote execution system reports that an operation

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -1334,6 +1334,17 @@ message ExecuteResponse {
 }
 
 // The current stage of action execution.
+//
+// Even though these stages are numbered according to the order in which
+// they generally occur, there is no requirement that the remote
+// execution system reports events along this order. For example, an
+// operation MAY to transition from the EXECUTING stage back to QUEUED
+// in case the hardware on which the operation executes fails.
+//
+// If and only if the remote execution system reports that an operation
+// has reached the COMPLETED stage, it MUST set the [done
+// field][google.longrunning.Operation.done] of the
+// [Operation][google.longrunning.Operation] and terminate the stream.
 message ExecutionStage {
   enum Value {
     // Invalid value.


### PR DESCRIPTION
As discussed during the 2021-05-11 working group meeting, we should make
it explicit that remote execution systems are permitted to report
ExecutionStages that don't transition forward (e.g., going from
EXECUTING back to QUEUED). The reason for this is twofold:

- It allows a remote execution system to retry actions in case of
  hardware failures.
- If the remote execution system performs automatic selection of worker
  sizes, it may need to rerun an action in case it picked a worker that
  was too small to run the action properly.