### PR TITLE
Use fully-qualified import paths in `go_package` options.

### DIFF
--- a/build/bazel/remote/asset/v1/remote_asset.proto
+++ b/build/bazel/remote/asset/v1/remote_asset.proto
@@ -23,7 +23,7 @@ import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
 
 option csharp_namespace = "Build.Bazel.Remote.Asset.v1";
-option go_package = "remoteasset";
+option go_package = "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1;remoteasset";
 option java_multiple_files = true;
 option java_outer_classname = "RemoteAssetProto";
 option java_package = "build.bazel.remote.asset.v1";

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -26,7 +26,7 @@ import "google/protobuf/wrappers.proto";
 import "google/rpc/status.proto";
 
 option csharp_namespace = "Build.Bazel.Remote.Execution.V2";
-option go_package = "remoteexecution";
+option go_package = "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2;remoteexecution";
 option java_multiple_files = true;
 option java_outer_classname = "RemoteExecutionProto";
 option java_package = "build.bazel.remote.execution.v2";

--- a/build/bazel/remote/logstream/v1/remote_logstream.proto
+++ b/build/bazel/remote/logstream/v1/remote_logstream.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package build.bazel.remote.logstream.v1;
 
 option csharp_namespace = "Build.Bazel.Remote.LogStream.v1";
-option go_package = "remotelogstream";
+option go_package = "github.com/bazelbuild/remote-apis/build/bazel/remote/logstream/v1;remotelogstream";
 option java_multiple_files = true;
 option java_outer_classname = "RemoteLogStreamProto";
 option java_package = "build.bazel.remote.logstream.v1";

--- a/build/bazel/semver/semver.proto
+++ b/build/bazel/semver/semver.proto
@@ -17,7 +17,7 @@ syntax = "proto3";
 package build.bazel.semver;
 
 option csharp_namespace = "Build.Bazel.Semver";
-option go_package = "semver";
+option go_package = "github.com/bazelbuild/remote-apis/build/bazel/semver";
 option java_multiple_files = true;
 option java_outer_classname = "SemverProto";
 option java_package = "build.bazel.semver";


### PR DESCRIPTION
The Protobuf documentation for [`go_package`][1] requires that it
contain a fully-qualified import path, with an optional package
name override.

As of [CL 301953][2] (released in [protobuf-go v1.26][3]), this
requirement is being enforced by the `protoc-gen-go` plugin.

I set the `go_package` options such that there is no change to
generated code compared to the previous version. This required
overriding the package names for the `remoteasset`, `remoteexecution`,
and `remotelogstream` packages, since those have import paths ending
in `/v1` or `/v2`.

Fixes #181

[1]: https://developers.google.com/protocol-buffers/docs/reference/go-generated#package
[2]: https://go-review.googlesource.com/c/protobuf/+/301953/
[3]: https://github.com/protocolbuffers/protobuf-go/releases/tag/v1.26.0