### PR TITLE
Move language-specific targets to subdirectories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,26 +56,6 @@ packages from that repository in order to generate code using this API. If you
 build the repository using the included `BUILD` files, Bazel will fetch the
 protobuf compiler and googleapis automatically.
 
-## Selecting language support
-
-The repository provides a rule that you can use in your `WORKSPACE` file to
-select which languages you are using. This allows you to depend on this
-repository without pulling in Go rules, for instance, if you aren't using Go
-rules.
-
-For instance, if you only use Java in your project, add the following to your
-`WORKSPACE` file:
-
-```starlark
-load("@bazel_remote_apis//:repository_rules.bzl", "switched_rules_by_language")
-switched_rules_by_language(
-    name = "bazel_remote_apis_imports",
-    java = True,
-)
-```
-
-You can find the complete list of supported languages in `repository_rules.bzl`.
-
 ## Using the APIs
 
 The repository contains `BUILD` files to build the protobuf library with

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -92,9 +92,11 @@ load("//:repository_rules.bzl", "switched_rules_by_language")
 switched_rules_by_language(
     name = "bazel_remote_apis_imports",
     cc = True,
-    go = True,
-    java = True,
 )
+
+load("//:remote_apis_deps.bzl", "remote_apis_go_deps")
+
+remote_apis_go_deps()
 
 # Needed for the googleapis protos.
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -87,13 +87,6 @@ bind(
     actual = "@com_github_grpc_grpc//:grpc++",
 )
 
-load("//:repository_rules.bzl", "switched_rules_by_language")
-
-switched_rules_by_language(
-    name = "bazel_remote_apis_imports",
-    cc = True,
-)
-
 load("//:remote_apis_deps.bzl", "remote_apis_go_deps")
 
 remote_apis_go_deps()

--- a/build/bazel/remote/asset/v1/BUILD
+++ b/build/bazel/remote/asset/v1/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@bazel_remote_apis_imports//:imports.bzl", "cc_grpc_library")
 
 licenses(["notice"])
 
@@ -23,18 +22,9 @@ alias(
     actual = "//build/bazel/remote/asset/v1/java:remote_asset_java_proto",
 )
 
-cc_grpc_library(
+alias(
     name = "remote_asset_cc_proto",
-    srcs = ["remote_asset.proto"],
-    proto_only = False,
-    use_external = False,
-    well_known_protos = True,
-    deps = [
-        "//build/bazel/remote/execution/v2:remote_execution_cc_proto",
-        "@googleapis//:google_api_annotations_cc_proto",
-        "@googleapis//:google_api_http_cc_proto",
-        "@googleapis//:google_rpc_status_cc_proto",
-    ],
+    actual = "//build/bazel/remote/asset/v1/cc:remote_asset_cc_grpc",
 )
 
 alias(

--- a/build/bazel/remote/asset/v1/BUILD
+++ b/build/bazel/remote/asset/v1/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@bazel_remote_apis_imports//:imports.bzl", "java_proto_library", "go_library", "go_proto_library", "cc_grpc_library")
+load("@bazel_remote_apis_imports//:imports.bzl", "cc_grpc_library")
 
 licenses(["notice"])
 
@@ -18,9 +18,9 @@ proto_library(
     ],
 )
 
-java_proto_library(
+alias(
     name = "remote_asset_java_proto",
-    deps = [":remote_asset_proto"],
+    actual = "//build/bazel/remote/asset/v1/java:remote_asset_java_proto",
 )
 
 cc_grpc_library(
@@ -37,20 +37,12 @@ cc_grpc_library(
     ],
 )
 
-go_proto_library(
+alias(
     name = "remote_asset_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
-    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1",
-    proto = ":remote_asset_proto",
-    deps = [
-        "//build/bazel/remote/execution/v2:go_default_library",
-        "@go_googleapis//google/api:annotations_go_proto",
-        "@go_googleapis//google/rpc:status_go_proto",
-    ],
+    actual = "//build/bazel/remote/asset/v1/go:remote_asset_go_proto",
 )
 
-go_library(
+alias(
     name = "go_default_library",
-    embed = [":remote_asset_go_proto"],
-    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1",
+    actual = "//build/bazel/remote/asset/v1/go:go_default_library",
 )

--- a/build/bazel/remote/asset/v1/cc/BUILD
+++ b/build/bazel/remote/asset/v1/cc/BUILD
@@ -1,0 +1,25 @@
+package(default_visibility = ["//build/bazel/remote/asset/v1:__pkg__"])
+
+load("//internal:cc_grpc_library.bzl", "cc_grpc_codegen")
+
+cc_proto_library(
+    name = "remote_asset_cc_proto",
+    deps = ["//build/bazel/remote/asset/v1:remote_asset_proto"],
+)
+
+cc_grpc_codegen(
+    name = "remote_asset_cc_grpc_codegen",
+    proto = "//build/bazel/remote/asset/v1:remote_asset_proto",
+)
+
+cc_library(
+    name = "remote_asset_cc_grpc",
+    srcs = [":remote_asset_cc_grpc_codegen"],
+    hdrs = [":remote_asset_cc_grpc_codegen"],
+    include_prefix = "build/bazel/remote/asset/v1",
+    strip_include_prefix = "/" + package_name(),
+    deps = [
+        ":remote_asset_cc_proto",
+        "@com_github_grpc_grpc//:grpc++_codegen_proto",
+    ],
+)

--- a/build/bazel/remote/asset/v1/go/BUILD
+++ b/build/bazel/remote/asset/v1/go/BUILD
@@ -1,0 +1,22 @@
+package(default_visibility = ["//build/bazel/remote/asset/v1:__pkg__"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "remote_asset_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1",
+    proto = "//build/bazel/remote/asset/v1:remote_asset_proto",
+    deps = [
+        "//build/bazel/remote/execution/v2:remote_execution_go_proto",
+        "@go_googleapis//google/api:annotations_go_proto",
+        "@go_googleapis//google/rpc:status_go_proto",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":remote_asset_go_proto"],
+    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1",
+)

--- a/build/bazel/remote/asset/v1/java/BUILD
+++ b/build/bazel/remote/asset/v1/java/BUILD
@@ -1,0 +1,6 @@
+package(default_visibility = ["//build/bazel/remote/asset/v1:__pkg__"])
+
+java_proto_library(
+    name = "remote_asset_java_proto",
+    deps = ["//build/bazel/remote/asset/v1:remote_asset_proto"],
+)

--- a/build/bazel/remote/execution/v2/BUILD
+++ b/build/bazel/remote/execution/v2/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@bazel_remote_apis_imports//:imports.bzl", "cc_grpc_library")
 
 licenses(["notice"])
 
@@ -26,19 +25,9 @@ alias(
     actual = "//build/bazel/remote/execution/v2/java:remote_execution_java_proto",
 )
 
-cc_grpc_library(
+alias(
     name = "remote_execution_cc_proto",
-    srcs = ["remote_execution.proto"],
-    proto_only = False,
-    use_external = False,
-    well_known_protos = True,
-    deps = [
-        "//build/bazel/semver:semver_cc_proto",
-        "@googleapis//:google_api_annotations_cc_proto",
-        "@googleapis//:google_api_http_cc_proto",
-        "@googleapis//:google_longrunning_operations_cc_proto",
-        "@googleapis//:google_rpc_status_cc_proto",
-    ],
+    actual = "//build/bazel/remote/execution/v2/cc:remote_execution_cc_grpc",
 )
 
 alias(

--- a/build/bazel/remote/execution/v2/BUILD
+++ b/build/bazel/remote/execution/v2/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@bazel_remote_apis_imports//:imports.bzl", "java_proto_library", "go_library", "go_proto_library", "cc_grpc_library")
+load("@bazel_remote_apis_imports//:imports.bzl", "cc_grpc_library")
 
 licenses(["notice"])
 
@@ -21,9 +21,9 @@ proto_library(
     ],
 )
 
-java_proto_library(
+alias(
     name = "remote_execution_java_proto",
-    deps = [":remote_execution_proto"],
+    actual = "//build/bazel/remote/execution/v2/java:remote_execution_java_proto",
 )
 
 cc_grpc_library(
@@ -41,21 +41,12 @@ cc_grpc_library(
     ],
 )
 
-go_proto_library(
+alias(
     name = "remote_execution_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
-    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2",
-    proto = ":remote_execution_proto",
-    deps = [
-        "//build/bazel/semver:go_default_library",
-        "@go_googleapis//google/api:annotations_go_proto",
-        "@go_googleapis//google/longrunning:longrunning_go_proto",
-        "@go_googleapis//google/rpc:status_go_proto",
-    ],
+    actual = "//build/bazel/remote/execution/v2/go:remote_execution_go_proto",
 )
 
-go_library(
+alias(
     name = "go_default_library",
-    embed = [":remote_execution_go_proto"],
-    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2",
+    actual = "//build/bazel/remote/execution/v2/go:go_default_library",
 )

--- a/build/bazel/remote/execution/v2/cc/BUILD
+++ b/build/bazel/remote/execution/v2/cc/BUILD
@@ -1,0 +1,25 @@
+package(default_visibility = ["//build/bazel/remote/execution/v2:__pkg__"])
+
+load("//internal:cc_grpc_library.bzl", "cc_grpc_codegen")
+
+cc_proto_library(
+    name = "remote_execution_cc_proto",
+    deps = ["//build/bazel/remote/execution/v2:remote_execution_proto"],
+)
+
+cc_grpc_codegen(
+    name = "remote_execution_cc_grpc_codegen",
+    proto = "//build/bazel/remote/execution/v2:remote_execution_proto",
+)
+
+cc_library(
+    name = "remote_execution_cc_grpc",
+    srcs = [":remote_execution_cc_grpc_codegen"],
+    hdrs = [":remote_execution_cc_grpc_codegen"],
+    include_prefix = "build/bazel/remote/execution/v2",
+    strip_include_prefix = "/" + package_name(),
+    deps = [
+        ":remote_execution_cc_proto",
+        "@com_github_grpc_grpc//:grpc++_codegen_proto",
+    ],
+)

--- a/build/bazel/remote/execution/v2/go/BUILD
+++ b/build/bazel/remote/execution/v2/go/BUILD
@@ -1,0 +1,23 @@
+package(default_visibility = ["//build/bazel/remote/execution/v2:__pkg__"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "remote_execution_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2",
+    proto = "//build/bazel/remote/execution/v2:remote_execution_proto",
+    deps = [
+        "//build/bazel/semver:semver_go_proto",
+        "@go_googleapis//google/api:annotations_go_proto",
+        "@go_googleapis//google/longrunning:longrunning_go_proto",
+        "@go_googleapis//google/rpc:status_go_proto",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":remote_execution_go_proto"],
+    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2",
+)

--- a/build/bazel/remote/execution/v2/java/BUILD
+++ b/build/bazel/remote/execution/v2/java/BUILD
@@ -1,0 +1,6 @@
+package(default_visibility = ["//build/bazel/remote/execution/v2:__pkg__"])
+
+java_proto_library(
+    name = "remote_execution_java_proto",
+    deps = ["//build/bazel/remote/execution/v2:remote_execution_proto"],
+)

--- a/build/bazel/remote/logstream/v1/BUILD
+++ b/build/bazel/remote/logstream/v1/BUILD
@@ -1,20 +1,18 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@bazel_remote_apis_imports//:imports.bzl", "java_proto_library", "go_library", "go_proto_library", "cc_grpc_library")
+load("@bazel_remote_apis_imports//:imports.bzl", "cc_grpc_library")
 
 licenses(["notice"])
 
 proto_library(
     name = "remote_logstream_proto",
     srcs = ["remote_logstream.proto"],
-    deps = [
-    ],
 )
 
-java_proto_library(
+alias(
     name = "remote_logstream_java_proto",
-    deps = [":remote_logstream_proto"],
+    actual = "//build/bazel/remote/logstream/v1/java:remote_logstream_java_proto",
 )
 
 cc_grpc_library(
@@ -27,17 +25,12 @@ cc_grpc_library(
     ],
 )
 
-go_proto_library(
+alias(
     name = "remote_logstream_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
-    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/logstream/v1",
-    proto = ":remote_logstream_proto",
-    deps = [
-    ],
+    actual = "//build/bazel/remote/logstream/v1/go:remote_logstream_go_proto",
 )
 
-go_library(
+alias(
     name = "go_default_library",
-    embed = [":remote_logstream_go_proto"],
-    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/logstream/v1",
+    actual = "//build/bazel/remote/logstream/v1/go:go_default_library",
 )

--- a/build/bazel/remote/logstream/v1/BUILD
+++ b/build/bazel/remote/logstream/v1/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@bazel_remote_apis_imports//:imports.bzl", "cc_grpc_library")
 
 licenses(["notice"])
 
@@ -15,14 +14,9 @@ alias(
     actual = "//build/bazel/remote/logstream/v1/java:remote_logstream_java_proto",
 )
 
-cc_grpc_library(
+alias(
     name = "remote_logstream_cc_proto",
-    srcs = ["remote_logstream.proto"],
-    proto_only = False,
-    use_external = False,
-    well_known_protos = True,
-    deps = [
-    ],
+    actual = "//build/bazel/remote/logstream/v1/cc:remote_logstream_cc_grpc",
 )
 
 alias(

--- a/build/bazel/remote/logstream/v1/cc/BUILD
+++ b/build/bazel/remote/logstream/v1/cc/BUILD
@@ -1,0 +1,25 @@
+package(default_visibility = ["//build/bazel/remote/logstream/v1:__pkg__"])
+
+load("//internal:cc_grpc_library.bzl", "cc_grpc_codegen")
+
+cc_proto_library(
+    name = "remote_logstream_cc_proto",
+    deps = ["//build/bazel/remote/logstream/v1:remote_logstream_proto"],
+)
+
+cc_grpc_codegen(
+    name = "remote_logstream_cc_grpc_codegen",
+    proto = "//build/bazel/remote/logstream/v1:remote_logstream_proto",
+)
+
+cc_library(
+    name = "remote_logstream_cc_grpc",
+    srcs = [":remote_logstream_cc_grpc_codegen"],
+    hdrs = [":remote_logstream_cc_grpc_codegen"],
+    include_prefix = "build/bazel/remote/logstream/v1",
+    strip_include_prefix = "/" + package_name(),
+    deps = [
+        ":remote_logstream_cc_proto",
+        "@com_github_grpc_grpc//:grpc++_codegen_proto",
+    ],
+)

--- a/build/bazel/remote/logstream/v1/go/BUILD
+++ b/build/bazel/remote/logstream/v1/go/BUILD
@@ -1,0 +1,17 @@
+package(default_visibility = ["//build/bazel/remote/logstream/v1:__pkg__"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "remote_logstream_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/logstream/v1",
+    proto = "//build/bazel/remote/logstream/v1:remote_logstream_proto",
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":remote_logstream_go_proto"],
+    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/logstream/v1",
+)

--- a/build/bazel/remote/logstream/v1/java/BUILD
+++ b/build/bazel/remote/logstream/v1/java/BUILD
@@ -1,0 +1,6 @@
+package(default_visibility = ["//build/bazel/remote/logstream/v1:__pkg__"])
+
+java_proto_library(
+    name = "remote_logstream_java_proto",
+    deps = ["//build/bazel/remote/logstream/v1:remote_logstream_proto"],
+)

--- a/build/bazel/semver/BUILD
+++ b/build/bazel/semver/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@bazel_remote_apis_imports//:imports.bzl", "java_proto_library", "go_library", "go_proto_library", "cc_grpc_library")
+load("@bazel_remote_apis_imports//:imports.bzl", "cc_grpc_library")
 
 licenses(["notice"])
 
@@ -10,9 +10,9 @@ proto_library(
     srcs = ["semver.proto"],
 )
 
-java_proto_library(
+alias(
     name = "semver_java_proto",
-    deps = [":semver_proto"],
+    actual = "//build/bazel/semver/java:semver_java_proto",
 )
 
 cc_grpc_library(
@@ -24,14 +24,12 @@ cc_grpc_library(
     deps = [],
 )
 
-go_proto_library(
+alias(
     name = "semver_go_proto",
-    importpath = "github.com/bazelbuild/remote-apis/build/bazel/semver",
-    proto = ":semver_proto",
+    actual = "//build/bazel/semver/go:semver_go_proto",
 )
 
-go_library(
+alias(
     name = "go_default_library",
-    embed = [":semver_go_proto"],
-    importpath = "github.com/bazelbuild/remote-apis/build/bazel/semver",
+    actual = "//build/bazel/semver/go:go_default_library",
 )

--- a/build/bazel/semver/BUILD
+++ b/build/bazel/semver/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@bazel_remote_apis_imports//:imports.bzl", "cc_grpc_library")
 
 licenses(["notice"])
 
@@ -15,13 +14,9 @@ alias(
     actual = "//build/bazel/semver/java:semver_java_proto",
 )
 
-cc_grpc_library(
+alias(
     name = "semver_cc_proto",
-    srcs = ["semver.proto"],
-    proto_only = False,
-    use_external = False,
-    well_known_protos = True,
-    deps = [],
+    actual = "//build/bazel/semver/cc:semver_cc_proto",
 )
 
 alias(

--- a/build/bazel/semver/cc/BUILD
+++ b/build/bazel/semver/cc/BUILD
@@ -1,0 +1,6 @@
+package(default_visibility = ["//build/bazel/semver:__pkg__"])
+
+cc_proto_library(
+    name = "semver_cc_proto",
+    deps = ["//build/bazel/semver:semver_proto"],
+)

--- a/build/bazel/semver/go/BUILD
+++ b/build/bazel/semver/go/BUILD
@@ -1,0 +1,16 @@
+package(default_visibility = ["//build/bazel/semver:__pkg__"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "semver_go_proto",
+    importpath = "github.com/bazelbuild/remote-apis/build/bazel/semver",
+    proto = "//build/bazel/semver:semver_proto",
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":semver_go_proto"],
+    importpath = "github.com/bazelbuild/remote-apis/build/bazel/semver",
+)

--- a/build/bazel/semver/java/BUILD
+++ b/build/bazel/semver/java/BUILD
@@ -1,0 +1,6 @@
+package(default_visibility = ["//build/bazel/semver:__pkg__"])
+
+java_proto_library(
+    name = "semver_java_proto",
+    deps = ["//build/bazel/semver:semver_proto"],
+)

--- a/internal/cc_grpc_library.bzl
+++ b/internal/cc_grpc_library.bzl
@@ -1,0 +1,118 @@
+"""Rule for running the gRPC C++ code generator.
+
+This is a simplified and modernised version of the upstream gRPC
+`bazel/cc_grpc_library.bzl` file, which as of release v1.45
+(published 2022-03-19) does not support separating the `proto_library` and
+`cc_proto_library` targets into separate packages or repositories.
+
+The following logic should eventually find a home in upstream gRPC, rules_proto,
+or rules_cc so that the Bazel Remote APIs repository can be further decoupled
+from language-specific concerns.
+"""
+
+load("@com_github_grpc_grpc//bazel:protobuf.bzl", "get_include_protoc_args")
+
+_EXT_PROTO = ".proto"
+_EXT_PROTODEVEL = ".protodevel"
+_EXT_GRPC_HDR = ".grpc.pb.h"
+_EXT_GRPC_SRC = ".grpc.pb.cc"
+
+def _drop_proto_ext(name):
+    if name.endswith(_EXT_PROTO):
+        return name[:-len(_EXT_PROTO)]
+    if name.endswith(_EXT_PROTODEVEL):
+        return name[:-len(_EXT_PROTODEVEL)]
+    fail("{!r} does not end with {!r} or {!r}".format(
+        name,
+        _EXT_PROTO,
+        _EXT_PROTODEVEL,
+    ))
+
+def _proto_srcname(file):
+    """Return the Protobuf source name for a proto_library source file.
+
+    The source name is what the Protobuf compiler uses to identify a .proto
+    source file. It is relative to the compiler's `--proto_path` flag.
+    """
+    ws_root = file.owner.workspace_root
+    if ws_root != "" and file.path.startswith(ws_root):
+        return file.path[len(ws_root) + 1:]
+    return file.short_path
+
+def _cc_grpc_codegen(ctx):
+    """Run the gRPC C++ code generator to produce sources and headers"""
+    proto = ctx.attr.proto[ProtoInfo]
+    proto_srcs = proto.check_deps_sources.to_list()
+    proto_imports = proto.transitive_imports.to_list()
+
+    protoc_out = ctx.actions.declare_directory(ctx.attr.name + "_protoc_out")
+    protoc_outputs = [protoc_out]
+    rule_outputs = []
+
+    for proto_src in proto_srcs:
+        srcname = _drop_proto_ext(_proto_srcname(proto_src))
+        basename = _drop_proto_ext(proto_src.basename)
+
+        out_hdr = ctx.actions.declare_file(basename + _EXT_GRPC_HDR)
+        out_src = ctx.actions.declare_file(basename + _EXT_GRPC_SRC)
+
+        protoc_out_prefix = protoc_out.basename
+        protoc_out_hdr = ctx.actions.declare_file(
+            "{}/{}".format(protoc_out_prefix, srcname + _EXT_GRPC_HDR),
+        )
+        protoc_out_src = ctx.actions.declare_file(
+            "{}/{}".format(protoc_out_prefix, srcname + _EXT_GRPC_SRC),
+        )
+
+        rule_outputs.extend([out_hdr, out_src])
+        protoc_outputs.extend([protoc_out_hdr, protoc_out_src])
+
+        ctx.actions.expand_template(
+            template = protoc_out_hdr,
+            output = out_hdr,
+            substitutions = {},
+        )
+        ctx.actions.expand_template(
+            template = protoc_out_src,
+            output = out_src,
+            substitutions = {},
+        )
+
+    plugin = ctx.executable._protoc_gen_grpc
+    protoc_args = ctx.actions.args()
+    protoc_args.add("--plugin", "protoc-gen-grpc=" + plugin.path)
+    protoc_args.add("--grpc_out", protoc_out.path)
+
+    protoc_args.add_all(get_include_protoc_args(proto_imports))
+    protoc_args.add_all(proto_srcs, map_each = _proto_srcname)
+
+    ctx.actions.run(
+        executable = ctx.executable._protoc,
+        arguments = [protoc_args],
+        inputs = proto_srcs + proto_imports,
+        outputs = protoc_outputs,
+        tools = [plugin],
+    )
+
+    return DefaultInfo(files = depset(rule_outputs))
+
+cc_grpc_codegen = rule(
+    implementation = _cc_grpc_codegen,
+    attrs = {
+        "proto": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            providers = [ProtoInfo],
+        ),
+        "_protoc_gen_grpc": attr.label(
+            default = Label("@com_github_grpc_grpc//src/compiler:grpc_cpp_plugin"),
+            executable = True,
+            cfg = "host",
+        ),
+        "_protoc": attr.label(
+            default = Label("//external:protocol_compiler"),
+            executable = True,
+            cfg = "host",
+        ),
+    },
+)

--- a/repository_rules.bzl
+++ b/repository_rules.bzl
@@ -1,56 +1,6 @@
-"""Repository rules and macros which are expected to be called from WORKSPACE
-file of either bazel_remote_apis itself or any third_party repository which
-consumes bazel_remote_apis as its dependency.
-
-This is adapted from
-https://github.com/googleapis/googleapis/blob/master/repository_rules.bzl
-"""
+"""Deprecated stub for compatibility with previous releases."""
 
 load("//:remote_apis_deps.bzl", "remote_apis_go_deps")
-
-def _switched_rules_impl(ctx):
-    disabled_rule_script = """
-def {rule_name}(**kwargs):
-    pass
-"""
-    enabled_native_rule_script = """
-{rule_name} = {native_rule_name}
-"""
-    enabled_rule_script = """
-load("{file_label}", _{rule_name} = "{rule_name}")
-"""
-    elabled_rule_scrip_alias = """
-{rule_name} = _{rule_name}
-"""
-    load_rules = []  # load() must go before everything else in .bzl files since Bazel 0.25.0
-    rules = []
-
-    for rule_name, value in ctx.attr.rules.items():
-        if not value:
-            rules.append(disabled_rule_script.format(rule_name = rule_name))
-        elif value.startswith("@"):
-            load_rules.append(enabled_rule_script.format(file_label = value, rule_name = rule_name))
-            rules.append(elabled_rule_scrip_alias.format(rule_name = rule_name))
-        elif value.startswith("native."):
-            rules.append(
-                enabled_native_rule_script.format(rule_name = rule_name, native_rule_name = value),
-            )
-        else:
-            rules.append(value)
-
-    ctx.file("BUILD.bazel", "")
-    ctx.file("imports.bzl", "".join(load_rules + rules))
-
-switched_rules = repository_rule(
-    implementation = _switched_rules_impl,
-    attrs = {
-        "rules": attr.string_dict(
-            allow_empty = True,
-            mandatory = False,
-            default = {},
-        ),
-    },
-)
 
 def switched_rules_by_language(
         name,
@@ -58,68 +8,11 @@ def switched_rules_by_language(
         go = False,
         cc = False,
         rules_override = {}):
-    """Switches rules in the generated imports.bzl between no-op and the actual
-    implementation.
-
-    This defines which language-specific rules should be enabled during the
-    build. All non-enabled language-specific rules will default to no-op
-    implementations.
-
-    For example, to use this rule and enable Java and Go rules, add the
-    following in the external repository which imports bazel_remote_apis
-    repository and its corresponding dependencies:
-
-        load("@bazel_remote_apis//:repository_rules.bzl", "switched_rules_by_language")
-
-        switched_rules_by_language(
-            name = "bazel_remote_apis_imports",
-            go = True,
-            java = True,
-        )
-
-    Then import e.g. "go_library" from @bazel_remote_apis_imports in your BUILD files:
-
-        load("@bazel_remote_apis_imports//:imports.bzl", "go_library")
-
-    Note, for build to work you must also import the language-specific transitive dependencies.
-
-    Args:
-        name (str): name of a target, is expected to be "bazel_remote_apis_imports".
-        java (bool): Enable Java specific rules. False by default.
-        go (bool): Enable Go specific rules. False by default.
-        cc (bool): Enable C++ specific rules. False by default.
-        rules_override (dict): Custom rule overrides (for advanced usage).
-    """
-
-    rules = {}
-
-    rules["java_proto_library"] = _switch(
-        java,
-        "native.java_proto_library",
-    )
-
-    rules["go_proto_library"] = _switch(
-        go,
-        "@io_bazel_rules_go//proto:def.bzl",
-    )
-    rules["go_library"] = _switch(
-        go,
-        "@io_bazel_rules_go//go:def.bzl",
-    )
-
-    rules["cc_grpc_library"] = _switch(
-        cc,
-        "@com_github_grpc_grpc//bazel:cc_grpc_library.bzl",
-    )
-
-    rules.update(rules_override)
-
-    switched_rules(
-        name = name,
-        rules = rules,
+    """Deprecated stub for compatibility with previous releases."""
+    print(
+        "The switched_rules_by_language macro is deprecated. Consumers of" +
+        " @bazel_remote_apis should specify per-language dependencies in" +
+        " their own workspace.",
     )
     if go:
         remote_apis_go_deps()
-
-def _switch(enabled, enabled_value):
-    return enabled_value if enabled else ""


### PR DESCRIPTION
As discussed during the working group's monthly meeting, this is a suggested change to improve the developer experience by eliminating the need for `@bazel_remote_apis_imports`.

The Go and Java targets are straightforward. Updating the C++ targets was more involved, because gRPC's upstream `cc_grpc_library` must be declared in the same package as the `proto_library` it depends on. This limitation prevents using it in a `cc/` subdir. It would also prevent moving the language-specific targets out into their own SDK repository in the future.

I've worked around this by creating a `cc_grpc_codegen` rule in `internal/cc_grpc_library.bzl`, which writes protoc outputs to a declared directory and then extracts individual output files to a package-relative path. I think it may be worth asking maintainers of gRPC and/or `rules_cc` and/or `rules_proto` to see if there might be a better home for this rule.

Tested by running `bazel build //...`. I also did more in-depth testing for the C++ change, by creating a separate workspace and building some gRPC clients + servers in it to verify no unexpected effects on the linker.

Fixes https://github.com/bazelbuild/remote-apis/issues/110