### PR TITLE
Add a note about ordering of Tree protos

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -1212,6 +1212,9 @@ message Tree {
   // recursively, all its children. In order to reconstruct the directory tree,
   // the client must take the digests of each of the child directories and then
   // build up a tree starting from the `root`.
+  // Servers SHOULD ensure that these are ordered consistently such that two
+  // actions producing equivalent output directories on the same server
+  // implementation also produce Tree messages with matching digests.
   repeated Directory children = 2;
 }
 


### PR DESCRIPTION
We recently discovered some nondeterminism in outputs because the Tree children were coming out in different orders. It looks like that specific case got fixed by https://github.com/bazelbuild/remote-apis-sdks/pull/411, but it seems worth noting for any future implementations.