### PR TITLE
platform.md: Add RISC-V ISA names `rv32g` and `rv64g`

### DIFF
--- a/build/bazel/remote/execution/v2/platform.md
+++ b/build/bazel/remote/execution/v2/platform.md
@@ -35,6 +35,8 @@ The following standard property `name`s are defined:
     - `arm-t32-be` (big endian)
     - `power-isa-be` (big endian)
     - `power-isa-le` (little endian)
+    - `rv32g` (little endian)
+    - `rv64g` (little endian)
     - `sparc-v9` (big endian)
     - `x86-32`
     - `x86-64`


### PR DESCRIPTION
This adds the two general-purpose RISC-V ISA standards to the platform lexicon using the official names from the RISC-V spec, as discussed in a monthly meeting (see also https://github.com/bazelbuild/remote-apis/pull/176#issuecomment-724762698).

This should be sufficient for general-purpose RISC-V support in REAPI clients and servers. If/when there is a use case for RISC-V ISA subsets/extensions in the context of REAPI, this can be discussed/added as a follow-up.