### PR TITLE
Remove RBE Cloud Alpha from the public list of RE implementations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ workers implement the Remote Worker API.
 * [BuildGrid](https://buildgrid.build/) (open source)
 * [EngFlow](https://www.engflow.com/) (commercial)
 * [Flare Build Execution](https://flare.build/products/flare-build-execution) (commercial)
-* [Remote Build Execution (Alpha)](https://blog.bazel.build/2018/10/05/remote-build-execution.html) (commercial)
 * [Scoot](https://github.com/twitter/scoot) (open source)
 * [Turbo Cache](https://github.com/allada/turbo-cache) (open source)
 


### PR DESCRIPTION
RBE stopped being a publicly-accessible service a long time ago.