### PR TITLE
platform.md: Add LoongArch ISA name `la64v100`

### DIFF
--- a/build/bazel/remote/execution/v2/platform.md
+++ b/build/bazel/remote/execution/v2/platform.md
@@ -33,6 +33,7 @@ The following standard property `name`s are defined:
     - `arm-a64-be` (big endian)
     - `arm-t32` (little endian)
     - `arm-t32-be` (big endian)
+    - `la64v100` (little endian)
     - `power-isa-be` (big endian)
     - `power-isa-le` (little endian)
     - `rv32g` (little endian)


### PR DESCRIPTION
This adds the base ISA [1] of the LoongArch architecture to the platform lexicon.

[1] https://loongson.github.io/LoongArch-Documentation/LoongArch-toolchain-conventions-EN.html