### PR TITLE
Embed partial ExecutedActionMetadata in ExecuteOperationMetadata

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -1471,6 +1471,10 @@ message ExecuteOperationMetadata {
   // [ByteStream.Read][google.bytestream.ByteStream.Read] to stream the
   // standard error from the endpoint hosting streamed responses.
   string stderr_stream_name = 4;
+
+  // Additional implementation-specific metadata to send along with the
+  // Operation.
+  repeated google.protobuf.Any auxiliary_metadata = 5;
 }
 
 // A request message for

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -1472,11 +1472,9 @@ message ExecuteOperationMetadata {
   // standard error from the endpoint hosting streamed responses.
   string stderr_stream_name = 4;
 
-  // Additional implementation-specific metadata to send along with the
-  // Operation. Servers MAY choose to populate this field with a partially
-  // complete [ExecutedActionMetadata][build.bazel.remote.execution.v2.ExecutedActionMetadata]
-  // message to provide updates on the ongoing execution.
-  repeated google.protobuf.Any auxiliary_metadata = 5;
+  // The client can read this field to view details about the ongoing
+  // execution.
+  ExecutedActionMetadata partial_execution_metadata = 5;
 }
 
 // A request message for

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -1473,7 +1473,9 @@ message ExecuteOperationMetadata {
   string stderr_stream_name = 4;
 
   // Additional implementation-specific metadata to send along with the
-  // Operation.
+  // Operation. Servers MAY choose to populate this field with a partially
+  // complete [ExecutedActionMetadata][build.bazel.remote.execution.v2.ExecutedActionMetadata]
+  // message to provide updates on the ongoing execution.
   repeated google.protobuf.Any auxiliary_metadata = 5;
 }
 


### PR DESCRIPTION
The `ExecutedActionMetadata` contains a lot of interesting information about the work that was done, such as the worker the job was run on, timestamps for various execution milestones, and so on. This information is currently only available after the work is complete, in the `ActionResult`. However, I think some of these things would be useful to look at while the execution is running as well, especially in the context of UI tools that can show the status of ongoing work (e.g. [bgd-browser](https://gitlab.com/BuildGrid/bgd-browser)).

Unfortunately, there isn't currently a place to put this in the longrunning `Operation` that clients get back when waiting for a job. The only metadata field is used by the `ExecuteOperationMetadata` message, which has a very limited set of fields. So this PR just adds an `ExecutedActionMetadata` field in `ExecuteOperationMetadata`.