### PR TITLE
[remote asset api] mention RESOURCE_EXHAUSTED with other error status codes

### DIFF
--- a/build/bazel/remote/asset/v1/remote_asset.pb.go
+++ b/build/bazel/remote/asset/v1/remote_asset.pb.go
@@ -260,6 +260,8 @@ type FetchBlobResponse struct {
 	//   requested an asset from a disallowed origin.
 	// * `ABORTED`: The operation could not be completed, typically due to a
 	//   failed consistency check.
+	// * `RESOURCE_EXHAUSTED`: There is insufficient quota of some resource to
+	//   perform the requested operation. The client may retry after a delay.
 	Status *status.Status `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
 	// The uri from the request that resulted in a successful retrieval, or from
 	// which the error indicated in `status` was obtained.
@@ -473,6 +475,8 @@ type FetchDirectoryResponse struct {
 	//   requested an asset from a disallowed origin.
 	// * `ABORTED`: The operation could not be completed, typically due to a
 	//   failed consistency check.
+	// * `RESOURCE_EXHAUSTED`: There is insufficient quota of some resource to
+	//   perform the requested operation. The client may retry after a delay.
 	Status *status.Status `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
 	// The uri from the request that resulted in a successful retrieval, or from
 	// which the error indicated in `status` was obtained.

--- a/build/bazel/remote/asset/v1/remote_asset.proto
+++ b/build/bazel/remote/asset/v1/remote_asset.proto
@@ -216,6 +216,8 @@ message FetchBlobResponse {
   //   requested an asset from a disallowed origin.
   // * `ABORTED`: The operation could not be completed, typically due to a
   //   failed consistency check.
+  // * `RESOURCE_EXHAUSTED`: There is insufficient quota of some resource to
+  //   perform the requested operation. The client may retry after a delay.
   google.rpc.Status status = 1;
 
   // The uri from the request that resulted in a successful retrieval, or from
@@ -295,6 +297,8 @@ message FetchDirectoryResponse {
   //   requested an asset from a disallowed origin.
   // * `ABORTED`: The operation could not be completed, typically due to a
   //   failed consistency check.
+  // * `RESOURCE_EXHAUSTED`: There is insufficient quota of some resource to
+  //   perform the requested operation. The client may retry after a delay.
   google.rpc.Status status = 1;
 
   // The uri from the request that resulted in a successful retrieval, or from


### PR DESCRIPTION
This status value was already mentioned in the Fetch service comments, but was not included in the FetchBlobResponse or FetchDirectoryResponse status field comments alongside some other similar values. Let's make this more clear.