### PR TITLE
Empower servers to restrict metadata

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -2051,27 +2051,42 @@ message RequestMetadata {
   // An identifier that ties multiple requests to the same action.
   // For example, multiple requests to the CAS, Action Cache, and Execution
   // API are used in order to compile foo.cc.
+  //
+  // Servers *MAY* impose restrictions on values of this field.
   string action_id = 2;
 
   // An identifier that ties multiple actions together to a final result.
   // For example, multiple actions are required to build and run foo_test.
+  //
+  // This *SHOULD* generally be an RFC 4122-compliant UUID. Servers *MAY*
+  // impose additional restrictions on the values of this field.
   string tool_invocation_id = 3;
 
   // An identifier to tie multiple tool invocations together. For example,
   // runs of foo_test, bar_test and baz_test on a post-submit of a given patch.
+  //
+  // This *SHOULD* generally be an RFC 4122-compliant UUID. Servers *MAY*
+  // impose additional restrictions on the values of this field.
   string correlated_invocations_id = 4;
 
   // A brief description of the kind of action, for example, CppCompile or GoLink.
-  // There is no standard agreed set of values for this, and they are expected to vary between different client tools.
+  // There is no standard agreed set of values for this, and they are expected to
+  // vary between different client tools.
+  //
+  // Servers *MAY* impose restrictions on values of this field.
   string action_mnemonic = 5;
 
   // An identifier for the target which produced this action.
   // No guarantees are made around how many actions may relate to a single target.
+  //
+  // Servers *MAY* impose restrictions on values of this field.
   string target_id = 6;
 
   // An identifier for the configuration in which the target was built,
   // e.g. for differentiating building host tools or different target platforms.
   // There is no expectation that this value will have any particular structure,
   // or equality across invocations, though some client tools may offer these guarantees.
+  //
+  // Servers *MAY* impose restrictions on values of this field.
   string configuration_id = 7;
 }


### PR DESCRIPTION
Today, clients can send arbitrary strings in `RequestMetadata`. This can cause issues for servers if, e.g., clients send an invocation ID in a right-to-left language and servers log the invocation ID together with an (English) log message (`invocation_id=שלום עולם!: Find missing blobs`) or if the invocation ID is used as part of the path for storing metadata on disk.