### PR TITLE
Support digest functions in remote_asset API

### DIFF
--- a/build/bazel/remote/asset/v1/remote_asset.proto
+++ b/build/bazel/remote/asset/v1/remote_asset.proto
@@ -240,14 +240,16 @@ message FetchBlobResponse {
   // The digest of the file's contents, available for download through the CAS.
   build.bazel.remote.execution.v2.Digest blob_digest = 5;
 
-  // This field SHOULD be set to the digest function that was used by the server
-  // to compute [FetchBlobResponse.blob_digest].
-  // Clients could use this to determine whether the server honors
-  // [FetchBlobRequest.digest_function] that was set in the request.
+  // Indicates if the server used the client-requested digest function for
+  // computing [FetchBlobResponse.blob_digest].
   //
-  // If unset, clients SHOULD default to use SHA256 regardless of the requested
-  // [FetchBlobRequest.digest_function].
-  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 6;
+  // If `true`, the server respected the [FetchBlobRequest.digest_function]
+  // choice made by the client. Clients can rely on this to verify that the
+  // server computed `blob_digest` using the requested digest function.
+  //
+  // If this field is unset, clients SHOULD assume SHA256 was used for digest
+  // computation, regardless of the function requested in [FetchBlobRequest.digest_function].
+  bool respect_digest_function = 6;
 }
 
 // A request message for
@@ -336,14 +338,16 @@ message FetchDirectoryResponse {
   // [ContentAddressableStorage.GetTree].
   build.bazel.remote.execution.v2.Digest root_directory_digest = 5;
 
-  // This field SHOULD be set to the digest function that was used by the server
-  // to compute [FetchBlobResponse.root_directory_digest].
-  // Clients could use this to determine whether the server honors
-  // [FetchDirectoryRequest.digest_function] that was set in the request.
+  // Indicates if the server used the client-requested digest function for
+  // computing [FetchBlobResponse.root_directory_digest].
   //
-  // If unset, clients SHOULD default to use SHA256 regardless of the requested
-  // [FetchDirectoryRequest.digest_function].
-  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 6;
+  // If `true`, the server respected the [FetchDirectoryRequest.digest_function]
+  // choice made by the client. Clients can rely on this to verify that the
+  // server computed `blob_digest` using the requested digest function.
+  //
+  // If this field is unset, clients SHOULD assume SHA256 was used for digest
+  // computation, regardless of the function requested in [FetchDirectoryRequest.digest_function].
+  bool respect_digest_function = 6;
 }
 
 // The Push service is complementary to the Fetch, and allows for

--- a/build/bazel/remote/asset/v1/remote_asset.proto
+++ b/build/bazel/remote/asset/v1/remote_asset.proto
@@ -201,6 +201,11 @@ message FetchBlobRequest {
   //
   // Specified qualifier names *MUST* be unique.
   repeated Qualifier qualifiers = 5;
+
+  // The digest function the server must use to compute the digest.
+  //
+  // If unset, the server SHOULD default to SHA256.
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 6;
 }
 
 // A response message for
@@ -402,6 +407,15 @@ message PushBlobRequest {
   // indirectly referencing unavailable blobs.
   repeated build.bazel.remote.execution.v2.Digest references_blobs = 6;
   repeated build.bazel.remote.execution.v2.Digest references_directories = 7;
+
+  // The digest function that was used to compute the blob digest.
+  //
+  // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
+  // SHA384, SHA512, or VSO, the client MAY leave this field unset. In
+  // that case the server SHOULD infer the digest function using the
+  // length of the action digest hash and the digest functions announced
+  // in the server's capabilities.
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 8;
 }
 
 // A response message for
@@ -442,6 +456,15 @@ message PushDirectoryRequest {
   // indirectly referencing unavailable blobs.
   repeated build.bazel.remote.execution.v2.Digest references_blobs = 6;
   repeated build.bazel.remote.execution.v2.Digest references_directories = 7;
+
+  // The digest function that was used to compute blob digests.
+  //
+  // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
+  // SHA384, SHA512, or VSO, the client MAY leave this field unset. In
+  // that case the server SHOULD infer the digest function using the
+  // length of the action digest hash and the digest functions announced
+  // in the server's capabilities.
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 8;
 }
 
 // A response message for

--- a/build/bazel/remote/asset/v1/remote_asset.proto
+++ b/build/bazel/remote/asset/v1/remote_asset.proto
@@ -239,6 +239,15 @@ message FetchBlobResponse {
   // The result of the fetch, if the status had code `OK`.
   // The digest of the file's contents, available for download through the CAS.
   build.bazel.remote.execution.v2.Digest blob_digest = 5;
+
+  // This field SHOULD be set to the digest function that was used by the server
+  // to compute [FetchBlobResponse.blob_digest].
+  // Clients could use this to determine whether the server honors
+  // [FetchBlobRequest.digest_function] that was set in the request.
+  //
+  // If unset, clients SHOULD default to use SHA256 regardless of the requested
+  // [FetchBlobRequest.digest_function].
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 6;
 }
 
 // A request message for
@@ -287,6 +296,11 @@ message FetchDirectoryRequest {
   //
   // Specified qualifier names *MUST* be unique.
   repeated Qualifier qualifiers = 5;
+
+  // The digest function the server must use to compute the digest.
+  //
+  // If unset, the server SHOULD default to SHA256.
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 6;
 }
 
 // A response message for
@@ -321,6 +335,15 @@ message FetchDirectoryResponse {
   // the root digest of a directory tree, suitable for fetching via
   // [ContentAddressableStorage.GetTree].
   build.bazel.remote.execution.v2.Digest root_directory_digest = 5;
+
+  // This field SHOULD be set to the digest function that was used by the server
+  // to compute [FetchBlobResponse.root_directory_digest].
+  // Clients could use this to determine whether the server honors
+  // [FetchDirectoryRequest.digest_function] that was set in the request.
+  //
+  // If unset, clients SHOULD default to use SHA256 regardless of the requested
+  // [FetchDirectoryRequest.digest_function].
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 6;
 }
 
 // The Push service is complementary to the Fetch, and allows for

--- a/build/bazel/remote/asset/v1/remote_asset.proto
+++ b/build/bazel/remote/asset/v1/remote_asset.proto
@@ -240,16 +240,14 @@ message FetchBlobResponse {
   // The digest of the file's contents, available for download through the CAS.
   build.bazel.remote.execution.v2.Digest blob_digest = 5;
 
-  // Indicates if the server used the client-requested digest function for
-  // computing [FetchBlobResponse.blob_digest].
+  // This field SHOULD be set to the digest function that was used by the server
+  // to compute [FetchBlobResponse.blob_digest].
+  // Clients could use this to determine whether the server honors
+  // [FetchBlobRequest.digest_function] that was set in the request.
   //
-  // If `true`, the server respected the [FetchBlobRequest.digest_function]
-  // choice made by the client. Clients can rely on this to verify that the
-  // server computed `blob_digest` using the requested digest function.
-  //
-  // If this field is unset, clients SHOULD assume SHA256 was used for digest
-  // computation, regardless of the function requested in [FetchBlobRequest.digest_function].
-  bool respect_digest_function = 6;
+  // If unset, clients SHOULD default to use SHA256 regardless of the requested
+  // [FetchBlobRequest.digest_function].
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 6;
 }
 
 // A request message for
@@ -338,16 +336,14 @@ message FetchDirectoryResponse {
   // [ContentAddressableStorage.GetTree].
   build.bazel.remote.execution.v2.Digest root_directory_digest = 5;
 
-  // Indicates if the server used the client-requested digest function for
-  // computing [FetchBlobResponse.root_directory_digest].
+  // This field SHOULD be set to the digest function that was used by the server
+  // to compute [FetchBlobResponse.root_directory_digest].
+  // Clients could use this to determine whether the server honors
+  // [FetchDirectoryRequest.digest_function] that was set in the request.
   //
-  // If `true`, the server respected the [FetchDirectoryRequest.digest_function]
-  // choice made by the client. Clients can rely on this to verify that the
-  // server computed `blob_digest` using the requested digest function.
-  //
-  // If this field is unset, clients SHOULD assume SHA256 was used for digest
-  // computation, regardless of the function requested in [FetchDirectoryRequest.digest_function].
-  bool respect_digest_function = 6;
+  // If unset, clients SHOULD default to use SHA256 regardless of the requested
+  // [FetchDirectoryRequest.digest_function].
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 6;
 }
 
 // The Push service is complementary to the Fetch, and allows for


### PR DESCRIPTION
This will allow client(like Bazel) to specify the `digest_function` to the remote server (so that `--experimental_remote_downloader` could use non-SHA256 digest functions).

This is a recreation of https://github.com/bazelbuild/remote-apis/pull/273/ with reviewers' comment addressed