### PR TITLE
Add readme notes for worker apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Typically, workers are domain specific, optimized for custom scheduling
 protocols defined by the server implementation.
 
 * [Remote Worker API](https://goo.gl/oojM5H)
-* [Buildfarn](https://bazelbuild.github.io/bazel-buildfarm/docs/architecture/queues/)
-* [Buildbarn](https://nluug.nl/bestanden/presentaties/2023-05-11-ed-schouten-buildbarn-a-distributed-build-cluster.pdf)
+* [Buildfarm](https://bazelbuild.github.io/bazel-buildfarm/docs/architecture/queues/)
+* [Buildbarn](https://github.com/buildbarn/bb-remote-execution/blob/master/pkg/proto/remoteworker/remoteworker.proto)
 * [BuildGrid](https://buildgrid.build/developer/data_model.html#rwapi)
 
 ## API Community

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ These tools use the Remote Execution API to distribute builds to workers.
 
 ### Servers
 These applications implement the Remote Execution API to serve build requests
-from the clients above. These are then distributed to workers; some of these
-workers implement the Remote Worker API.
+from the clients above. Client requests are then distributed to workers.
 
 * [bazel-remote](https://github.com/buchgr/bazel-remote) (open source, cache only)
 * [Buildbarn](https://github.com/buildbarn) (open source)
@@ -67,6 +66,18 @@ workers implement the Remote Worker API.
 * [Kajiya](https://chromium.googlesource.com/infra/infra/+/refs/heads/main/go/src/infra/build/kajiya/) (open source)
 * [Scoot](https://github.com/twitter/scoot) (open source)
 * [Turbo Cache](https://github.com/allada/turbo-cache) (open source)
+
+### Workers
+Servers are responsible for managing a pool of workers.
+The Remote Worker API defines a reference protocol for worker and server
+communication, although, adhering to this protocol is not a requirement.
+Typically, workers are domain specific, optimized for custom scheduling
+protocols defined by the server implementation.
+
+* [Remote Worker API](https://goo.gl/oojM5H)
+* [Buildfarn](https://bazelbuild.github.io/bazel-buildfarm/docs/architecture/queues/)
+* [Buildbarn](https://nluug.nl/bestanden/presentaties/2023-05-11-ed-schouten-buildbarn-a-distributed-build-cluster.pdf)
+* [BuildGrid](https://buildgrid.build/developer/data_model.html#rwapi)
 
 ## API Community
 


### PR DESCRIPTION
Adding a note into the readme, aimed at new contributors and groups looking to design their own REAPI system.

The main point I wanted to add, is that there is no standardization on how schedulers/servers and workers must communicate. I provided some reference documentation which I found while doing my own research on scheduling implementations.

If there are more links from other implementations we should add them as well!