### PR TITLE
remote_asset: link digest_function & checksum qual

### DIFF
--- a/build/bazel/remote/asset/v1/remote_asset.proto
+++ b/build/bazel/remote/asset/v1/remote_asset.proto
@@ -205,6 +205,8 @@ message FetchBlobRequest {
   // The digest function the server must use to compute the digest.
   //
   // If unset, the server SHOULD default to SHA256.
+  // If set, the function MUST be the same with the digest function used in
+  // "checksum.sri", the subresource integrity qualifier.
   build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 6;
 }
 
@@ -300,6 +302,8 @@ message FetchDirectoryRequest {
   // The digest function the server must use to compute the digest.
   //
   // If unset, the server SHOULD default to SHA256.
+  // If set, the function MUST be the same with the digest function used in
+  // "checksum.sri", the subresource integrity qualifier.
   build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 6;
 }
 
@@ -438,6 +442,9 @@ message PushBlobRequest {
   // that case the server SHOULD infer the digest function using the
   // length of the action digest hash and the digest functions announced
   // in the server's capabilities.
+  //
+  // If set, the function MUST be the same with the digest function used in
+  // "checksum.sri", the subresource integrity qualifier.
   build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 8;
 }
 
@@ -487,6 +494,9 @@ message PushDirectoryRequest {
   // that case the server SHOULD infer the digest function using the
   // length of the action digest hash and the digest functions announced
   // in the server's capabilities.
+  //
+  // If set, the function MUST be the same with the digest function used in
+  // "checksum.sri", the subresource integrity qualifier.
   build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 8;
 }
 


### PR DESCRIPTION
Ensure that the digest function in requests is consistent with the
digest function used in `checksum.sri` qualifier, this way server
implementations do not have to support replicating blob from one digest
function to another.

Such functionality is not the intended use case of Remote Asset APIs
and, instead, could be achieved via a different client-side API call.
