### PR TITLE
remote_execution: add routing header to ByteStream

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -325,12 +325,12 @@ service ActionCache {
 // each of the compression formats that the server supports, as well as in
 // uncompressed form.
 //
-// Additionally, ByteStream RPCs MAY come with an additional plain text header
+// Additionally, ByteStream requests MAY come with an additional plain text header
 // that indicates the `resource_name` of the blob being sent.  The header, if
 // present, MUST follow the following convention:
 // * name: `build.bazel.remote.execution.v2.resource-name`.
 // * contents: the plain text resource_name of the request message.
-// The contents of the header MUST match the `resource_name` of the request
+// If set, the contents of the header MUST match the `resource_name` of the request
 // message.  Servers MAY use this header to assist in routing requests to the
 // appropriate backend.
 //

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -325,6 +325,15 @@ service ActionCache {
 // each of the compression formats that the server supports, as well as in
 // uncompressed form.
 //
+// Additionally, ByteStream RPCs MAY come with an additional plain text header
+// that indicates the `resource_name` of the blob being sent.  The header, if
+// present, MUST follow the following convention:
+// * name: `build.bazel.remote.execution.v2.resource-name`.
+// * contents: the plain text resource_name of the request message.
+// The contents of the header MUST match the `resource_name` of the request
+// message.  Servers MAY use this header to assist in routing requests to the
+// appropriate backend.
+//
 // The lifetime of entries in the CAS is implementation specific, but it SHOULD
 // be long enough to allow for newly-added and recently looked-up entries to be
 // used in subsequent calls (e.g. to


### PR DESCRIPTION
Add optional routing header for ByteStream RPCs.