### PR TITLE
Improve phrasing of digest_function added in #311

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.pb.go
+++ b/build/bazel/remote/execution/v2/remote_execution.pb.go
@@ -2799,11 +2799,11 @@ type ExecuteOperationMetadata struct {
 	PartialExecutionMetadata *ExecutedActionMetadata `protobuf:"bytes,5,opt,name=partial_execution_metadata,json=partialExecutionMetadata,proto3" json:"partial_execution_metadata,omitempty"`
 	// The digest function that was used to compute the action digest.
 	//
-	// If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
-	// SHA384, SHA512, or VSO, the client MAY leave this field unset. In
-	// that case the server SHOULD infer the digest function using the
-	// length of the action digest hash and the digest functions announced
-	// in the server's capabilities.
+	// If the digest function used is one of BLAKE3, MD5, MURMUR3, SHA1,
+	// SHA256, SHA256TREE, SHA384, SHA512, or VSO, the server MAY leave
+	// this field unset. In that case the client SHOULD infer the digest
+	// function using the length of the action digest hash and the digest
+	// functions announced in the server's capabilities.
 	DigestFunction DigestFunction_Value `protobuf:"varint,6,opt,name=digest_function,json=digestFunction,proto3,enum=build.bazel.remote.execution.v2.DigestFunction_Value" json:"digest_function,omitempty"`
 }
 

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -1560,11 +1560,11 @@ message ExecuteOperationMetadata {
 
   // The digest function that was used to compute the action digest.
   //
-  // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
-  // SHA384, SHA512, or VSO, the client MAY leave this field unset. In
-  // that case the server SHOULD infer the digest function using the
-  // length of the action digest hash and the digest functions announced
-  // in the server's capabilities.
+  // If the digest function used is one of BLAKE3, MD5, MURMUR3, SHA1,
+  // SHA256, SHA256TREE, SHA384, SHA512, or VSO, the server MAY leave
+  // this field unset. In that case the client SHOULD infer the digest
+  // function using the length of the action digest hash and the digest
+  // functions announced in the server's capabilities.
   DigestFunction.Value digest_function = 6;
 }
 


### PR DESCRIPTION
- Unlike the other messages where a digest_function field was added, ExecuteActionMetadata is returned by the server to the client. This means that the words "client" and "server" need to be swapped around in some but not all places.

- To ensure backward compatibility, we permit digest functions that were defined at the time this field was added to remain unset. When the digest_function fields were added to the other messages, the last one to be added was MURMUR3. In the meantime we've added BLAKE3 and SHA256TREE, so for this specific field we must list those as well.