### PR TITLE
Add max_blob_size_bytes to CacheCapabilities

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -2056,6 +2056,11 @@ message CacheCapabilities {
   // [BatchUpdateBlobs][build.bazel.remote.execution.v2.ContentAddressableStorage.BatchUpdateBlobs]
   // requests.
   repeated Compressor.Value supported_batch_update_compressors = 7;
+
+  // Maximum size of blobs that the server will accept in uploads.
+  // A value of 0 means no limit is set, not that blob uploads are
+  // not accepted.
+  int64 max_blob_size_bytes = 8;
 }
 
 // Capabilities of the remote execution system.


### PR DESCRIPTION
Some CAS implementations place an upper limit on the size of blobs that they will accept in uploads. There is currently no standard way for clients to query cache servers for this limit, and rejected large uploads can be slow.

So let's add this to the CacheCapabilities API. For backwards compatibility, a value of 0 means "no specified limit" (ie not "no uploads allowed").

* Bazel-remote has a `--max_blob_size` flag to specify an optional limit.
* Buildfarm appears to check against a blob size limit here: https://github.com/buildfarm/buildfarm/blob/4c539f6655e70b571f0604a31f8a15a8fb0d5d99/src/main/java/build/buildfarm/instance/shard/ServerInstance.java#L1454