### PR TITLE
asset API: loosen restrictions on qualifiers

### DIFF
--- a/build/bazel/remote/asset/v1/remote_asset.proto
+++ b/build/bazel/remote/asset/v1/remote_asset.proto
@@ -112,7 +112,8 @@ service Fetch {
   // correctly, without validation.
   //
   // Servers not implementing the complementary [Push][build.bazel.remote.asset.v1.Push]
-  // API *MUST* reject requests containing qualifiers it does not support.
+  // API *MAY* reject requests containing qualifiers it does not support, if the
+  // supported qualifiers specified in the request were insufficient by themselves.
   //
   // Servers *MAY* transform assets as part of the fetch. For example a
   // tarball fetched by [FetchDirectory][build.bazel.remote.asset.v1.Fetch.FetchDirectory]

--- a/build/bazel/remote/asset/v1/remote_asset_grpc.pb.go
+++ b/build/bazel/remote/asset/v1/remote_asset_grpc.pb.go
@@ -69,7 +69,8 @@ type FetchClient interface {
 	// correctly, without validation.
 	//
 	// Servers not implementing the complementary [Push][build.bazel.remote.asset.v1.Push]
-	// API *MUST* reject requests containing qualifiers it does not support.
+	// API *MAY* reject requests containing qualifiers it does not support, if the
+	// supported qualifiers specified in the request were insufficient by themselves.
 	//
 	// Servers *MAY* transform assets as part of the fetch. For example a
 	// tarball fetched by [FetchDirectory][build.bazel.remote.asset.v1.Fetch.FetchDirectory]
@@ -160,7 +161,8 @@ type FetchServer interface {
 	// correctly, without validation.
 	//
 	// Servers not implementing the complementary [Push][build.bazel.remote.asset.v1.Push]
-	// API *MUST* reject requests containing qualifiers it does not support.
+	// API *MAY* reject requests containing qualifiers it does not support, if the
+	// supported qualifiers specified in the request were insufficient by themselves.
 	//
 	// Servers *MAY* transform assets as part of the fetch. For example a
 	// tarball fetched by [FetchDirectory][build.bazel.remote.asset.v1.Fetch.FetchDirectory]


### PR DESCRIPTION
The spec previously stated that servers must reject Fetch requests if there were unsupported qualifiers specified. This was too strict- consider for example a scenario where the client specifies both SHA256 and SHA512 qualifiers, and the server only supports one of these. Supporting only one of these should be sufficient, and the server should be free to accept such a request.