### PR TITLE
[remote asset api] Clarify encoding of checksum.sri

### DIFF
--- a/build/bazel/remote/asset/v1/qualifiers.md
+++ b/build/bazel/remote/asset/v1/qualifiers.md
@@ -28,7 +28,9 @@ The following standard qualifier `name`s are defined:
   ```   
 
 * `checksum.sri`: The value represents a [Subresource Integrity](https://www.w3.org/TR/SRI/)
-  checksum of the content.
+  checksum of the content. Multiple checksums may be specified, separated by
+  whitespace. The Qualifier is satisfied if the server validates at least one of the
+  provided checksums, although it may choose to validate more than one.
 
   Example:
   ```json


### PR DESCRIPTION
The SRI specification specifically allows for more than one checksum to be part of integrity metadata (https://www.w3.org/TR/SRI/). The possible presence of more than one checksum is not immediately obvious without reading the specification, so we add a clarification.