### PR TITLE
platform.md: Define RemoteApisSocketPath for nested remote execution

### DIFF
--- a/build/bazel/remote/execution/v2/platform.md
+++ b/build/bazel/remote/execution/v2/platform.md
@@ -124,3 +124,12 @@ The following standard property `name`s are defined:
     ]
   }
   ```
+
+* `RemoteApisSocketPath`: This requests Remote APIs to be made available in
+  the execution environment via a UNIX socket at the specified path. The
+  path is relative to the input root.
+
+  The APIs and capabilities offered is implementation-specific and servers
+  MAY impose additional restrictions and/or resource limits on nested remote
+  execution clients. The Capabilities API may be used by remote commands to
+  query server properties.


### PR DESCRIPTION
This defines `RemoteApisSocketPath` as a new platform property to optionally provide remote commands access to the Remote APIs via a UNIX socket at a specified path.

This is intended to e.g. support running Bazel as a remote command while allowing the remote Bazel to then use nested remote execution or remote caching for individual actions. Or to use recc to speed up compilations within a package build that is also using remote execution (e.g. recc in BuildStream).