### PR TITLE
Update README.md with Nativelink's commercial status-change

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ from the clients above.
 * [Flare Build Execution](https://flare.build/products/flare-build-execution) (commercial)
 * [Justbuild](https://github.com/just-buildsystem/justbuild/blob/master/doc/tutorial/just-execute.org) (via `--compatible`, open source)
 * [Kajiya](https://chromium.googlesource.com/infra/infra/+/refs/heads/main/go/src/infra/build/kajiya/) (open source)
-* [NativeLink](https://github.com/TraceMachina/nativelink) (open source)
+* [NativeLink](https://github.com/TraceMachina/nativelink) (commercial and open source)
 * [Scoot](https://github.com/twitter/scoot) (open source)
 
 ### Workers


### PR DESCRIPTION
Nativelink now offers a commercial service in addition to our open source offering.