### PR TITLE
Add load() directives to keep Bazel 9.0.0rc1 happy

### DIFF
--- a/build/bazel/remote/asset/v1/BUILD
+++ b/build/bazel/remote/asset/v1/BUILD
@@ -1,4 +1,6 @@
 load("@grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@rules_go//go:def.bzl", "go_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")

--- a/build/bazel/remote/execution/v2/BUILD
+++ b/build/bazel/remote/execution/v2/BUILD
@@ -1,4 +1,6 @@
 load("@grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@rules_go//go:def.bzl", "go_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")

--- a/build/bazel/remote/logstream/v1/BUILD
+++ b/build/bazel/remote/logstream/v1/BUILD
@@ -1,4 +1,6 @@
 load("@grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@rules_go//go:def.bzl", "go_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")

--- a/build/bazel/semver/BUILD
+++ b/build/bazel/semver/BUILD
@@ -1,3 +1,5 @@
+load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@rules_go//go:def.bzl", "go_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")


### PR DESCRIPTION
These rules are no longer built into this version of Bazel. They are now provided by the Protobuf module.