### PR TITLE
Also include @werkt in CODEOWERS.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bwkimmel @EdSchouten @EricBurnett @fmeum @sluongng @sstriker @tjgq @ulfjack
+* @bwkimmel @EdSchouten @EricBurnett @fmeum @sluongng @sstriker @tjgq @ulfjack @werkt


### PR DESCRIPTION
He was accidentally missing from https://github.com/bazelbuild/remote-apis/pull/342.