### PR TITLE
feat(chunking): differentiate between a chunked and full blob

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -496,6 +496,21 @@ service ContentAddressableStorage {
   //   reconstruct the blob is missing from the CAS.
   // * `RESOURCE_EXHAUSTED`: There is insufficient disk quota to store the blob
   //   chunks.
+  // * `INVALID_ARGUMENT`: The requested blob is present in the CAS, but
+  //   the server will not perform the chunking operation. This may occur when
+  //   the server stores the blob in non-chunked format and does not support
+  //   on-demand chunking. Clients receiving this error MAY fall back to
+  //   downloading the blob using [Read][google.bytestream.ByteStream.Read].
+  //
+  // Note: A response containing a single chunk digest is a valid result, not
+  // an error. This occurs when the content-defined chunking algorithm finds
+  // no split points within the blob (e.g., for blobs smaller than the maximum
+  // chunk size). Clients SHOULD handle single-chunk responses the same as
+  // multi-chunk responses.
+  //
+  // Servers MUST NOT return the original blob digest as a single "chunk" if
+  // the chunking algorithm was not actually executed. If the server has the
+  // blob but will not perform chunking, it MUST return INVALID_ARGUMENT.
   rpc SplitBlob(SplitBlobRequest) returns (SplitBlobResponse) {
     option (google.api.http) = { get: "/v2/{instance_name=**}/blobs/{blob_digest.hash}/{blob_digest.size_bytes}:splitBlob" };
   }


### PR DESCRIPTION
A lot of time, a remote executor will be serving traffic for many versions of clients Bazel 7, Buck 2, etc. Some of the clients will not support chunking, and some will.

One important feature is that a large file in the CAS, the client should be able to determine:
- If the remote stores the file with chunking
- If the remote stores the file, but not with chunking

A more strict chunking client will only accept the first option, and will write any new entries in chunked format, even if the full blob exists. 

Another option here is to have the server return a `[]digest{blobDigest}`. Which can also be handled. However, this is less precise because it doesn't differentiate if the chunking produced a single blob, or if the blob was not chunked, which is a very important distinction.

Using a "precondition" error feels like the most idiomatic error for this situation, since the "precondition" of chunking the blob, was not completed.