### PR TITLE
Add an indirection field to split/splice calls

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.pb.go
+++ b/build/bazel/remote/execution/v2/remote_execution.pb.go
@@ -303,7 +303,7 @@ func (x DigestFunction_Value) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use DigestFunction_Value.Descriptor instead.
 func (DigestFunction_Value) EnumDescriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{40, 0}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{41, 0}
 }
 
 type ChunkingFunction_Value int32
@@ -360,7 +360,7 @@ func (x ChunkingFunction_Value) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ChunkingFunction_Value.Descriptor instead.
 func (ChunkingFunction_Value) EnumDescriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{41, 0}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{42, 0}
 }
 
 type SymlinkAbsolutePathStrategy_Value int32
@@ -416,7 +416,7 @@ func (x SymlinkAbsolutePathStrategy_Value) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SymlinkAbsolutePathStrategy_Value.Descriptor instead.
 func (SymlinkAbsolutePathStrategy_Value) EnumDescriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{44, 0}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{45, 0}
 }
 
 type Compressor_Value int32
@@ -478,7 +478,7 @@ func (x Compressor_Value) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Compressor_Value.Descriptor instead.
 func (Compressor_Value) EnumDescriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{45, 0}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{46, 0}
 }
 
 // An `Action` captures all the information about an execution which is required
@@ -3673,6 +3673,53 @@ func (x *GetTreeResponse) GetNextPageToken() string {
 	return ""
 }
 
+// A ChunkList is a list of chunks stored in the CAS. The Digest of a ChunkList
+// is computed over its protobuf wire format serialization.
+type ChunkList struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// An ordered list of chunk digests.
+	ChunkDigests  []*Digest `protobuf:"bytes,1,rep,name=chunk_digests,json=chunkDigests,proto3" json:"chunk_digests,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ChunkList) Reset() {
+	*x = ChunkList{}
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ChunkList) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ChunkList) ProtoMessage() {}
+
+func (x *ChunkList) ProtoReflect() protoreflect.Message {
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ChunkList.ProtoReflect.Descriptor instead.
+func (*ChunkList) Descriptor() ([]byte, []int) {
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *ChunkList) GetChunkDigests() []*Digest {
+	if x != nil {
+		return x.ChunkDigests
+	}
+	return nil
+}
+
 // A request message for
 // [ContentAddressableStorage.SplitBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitBlob].
 type SplitBlobRequest struct {
@@ -3703,7 +3750,7 @@ type SplitBlobRequest struct {
 
 func (x *SplitBlobRequest) Reset() {
 	*x = SplitBlobRequest{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[34]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3715,7 +3762,7 @@ func (x *SplitBlobRequest) String() string {
 func (*SplitBlobRequest) ProtoMessage() {}
 
 func (x *SplitBlobRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[34]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3728,7 +3775,7 @@ func (x *SplitBlobRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitBlobRequest.ProtoReflect.Descriptor instead.
 func (*SplitBlobRequest) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{34}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *SplitBlobRequest) GetInstanceName() string {
@@ -3765,20 +3812,29 @@ type SplitBlobResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The ordered list of digests of the chunks into which the blob was split.
 	// The original blob is assembled by concatenating the chunk data according to
-	// the order of the digests given by this list.
+	// the order of the digests given by this list. If the indirect_chunk_list is
+	// set this is instead a prefix of the indirect_chunk_list and the original
+	// blob is assembled by concatenating the chunk data expressed by the
+	// indirect_chunk_list.
 	//
 	// The server MUST use the same digest function as the one explicitly or
 	// implicitly (through hash length) specified in the split request.
 	ChunkDigests []*Digest `protobuf:"bytes,1,rep,name=chunk_digests,json=chunkDigests,proto3" json:"chunk_digests,omitempty"`
 	// The chunking function used to split the blob.
 	ChunkingFunction ChunkingFunction_Value `protobuf:"varint,2,opt,name=chunking_function,json=chunkingFunction,proto3,enum=build.bazel.remote.execution.v2.ChunkingFunction_Value" json:"chunking_function,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// The digest of the indirect chunk list which MUST be present in the
+	// [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage].
+	// The server MAY set this field in addition to the chunk_digests field. If
+	// set the chunk_digests field MUST be a prefix of the indirect_chunk_list and
+	// the indirect_chunk_list represents the full list of chunks for the blob.
+	IndirectChunkList *Digest `protobuf:"bytes,6,opt,name=indirect_chunk_list,json=indirectChunkList,proto3" json:"indirect_chunk_list,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *SplitBlobResponse) Reset() {
 	*x = SplitBlobResponse{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[35]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3790,7 +3846,7 @@ func (x *SplitBlobResponse) String() string {
 func (*SplitBlobResponse) ProtoMessage() {}
 
 func (x *SplitBlobResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[35]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3803,7 +3859,7 @@ func (x *SplitBlobResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitBlobResponse.ProtoReflect.Descriptor instead.
 func (*SplitBlobResponse) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{35}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *SplitBlobResponse) GetChunkDigests() []*Digest {
@@ -3818,6 +3874,13 @@ func (x *SplitBlobResponse) GetChunkingFunction() ChunkingFunction_Value {
 		return x.ChunkingFunction
 	}
 	return ChunkingFunction_UNKNOWN
+}
+
+func (x *SplitBlobResponse) GetIndirectChunkList() *Digest {
+	if x != nil {
+		return x.IndirectChunkList
+	}
+	return nil
 }
 
 // A request message for
@@ -3844,7 +3907,10 @@ type SpliceBlobRequest struct {
 	//     new chunking information.
 	BlobDigest *Digest `protobuf:"bytes,2,opt,name=blob_digest,json=blobDigest,proto3" json:"blob_digest,omitempty"`
 	// The ordered list of digests of the chunks which need to be concatenated to
-	// assemble the original blob.
+	// assemble the original blob. If the indirect_chunk_list is set this is
+	// instead a prefix of the indirect_chunk_list and the original blob is
+	// assembled by concatenating the chunk data expressed by the
+	// indirect_chunk_list.
 	ChunkDigests []*Digest `protobuf:"bytes,3,rep,name=chunk_digests,json=chunkDigests,proto3" json:"chunk_digests,omitempty"`
 	// The digest function of all chunks to be concatenated and of the blob to be
 	// spliced. The server MUST use the same digest function for both cases.
@@ -3856,13 +3922,18 @@ type SpliceBlobRequest struct {
 	DigestFunction DigestFunction_Value `protobuf:"varint,4,opt,name=digest_function,json=digestFunction,proto3,enum=build.bazel.remote.execution.v2.DigestFunction_Value" json:"digest_function,omitempty"`
 	// The chunking function that the client used to split the blob.
 	ChunkingFunction ChunkingFunction_Value `protobuf:"varint,5,opt,name=chunking_function,json=chunkingFunction,proto3,enum=build.bazel.remote.execution.v2.ChunkingFunction_Value" json:"chunking_function,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// The digest of the indirect chunk list stored in the CAS. The client MAY set
+	// this field in addition to the chunk_digests field. If set the chunk_digests
+	// field MUST be a prefix of the indirect_chunk_list and the
+	// indirect_chunk_list represents the full list of chunks for the blob.
+	IndirectChunkList *Digest `protobuf:"bytes,6,opt,name=indirect_chunk_list,json=indirectChunkList,proto3" json:"indirect_chunk_list,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *SpliceBlobRequest) Reset() {
 	*x = SpliceBlobRequest{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[36]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3874,7 +3945,7 @@ func (x *SpliceBlobRequest) String() string {
 func (*SpliceBlobRequest) ProtoMessage() {}
 
 func (x *SpliceBlobRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[36]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3887,7 +3958,7 @@ func (x *SpliceBlobRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpliceBlobRequest.ProtoReflect.Descriptor instead.
 func (*SpliceBlobRequest) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{36}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *SpliceBlobRequest) GetInstanceName() string {
@@ -3925,6 +3996,13 @@ func (x *SpliceBlobRequest) GetChunkingFunction() ChunkingFunction_Value {
 	return ChunkingFunction_UNKNOWN
 }
 
+func (x *SpliceBlobRequest) GetIndirectChunkList() *Digest {
+	if x != nil {
+		return x.IndirectChunkList
+	}
+	return nil
+}
+
 // A response message for
 // [ContentAddressableStorage.SpliceBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceBlob].
 type SpliceBlobResponse struct {
@@ -3940,7 +4018,7 @@ type SpliceBlobResponse struct {
 
 func (x *SpliceBlobResponse) Reset() {
 	*x = SpliceBlobResponse{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[37]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3952,7 +4030,7 @@ func (x *SpliceBlobResponse) String() string {
 func (*SpliceBlobResponse) ProtoMessage() {}
 
 func (x *SpliceBlobResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[37]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3965,7 +4043,7 @@ func (x *SpliceBlobResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpliceBlobResponse.ProtoReflect.Descriptor instead.
 func (*SpliceBlobResponse) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{37}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *SpliceBlobResponse) GetBlobDigest() *Digest {
@@ -3991,7 +4069,7 @@ type GetCapabilitiesRequest struct {
 
 func (x *GetCapabilitiesRequest) Reset() {
 	*x = GetCapabilitiesRequest{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[38]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4003,7 +4081,7 @@ func (x *GetCapabilitiesRequest) String() string {
 func (*GetCapabilitiesRequest) ProtoMessage() {}
 
 func (x *GetCapabilitiesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[38]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4016,7 +4094,7 @@ func (x *GetCapabilitiesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCapabilitiesRequest.ProtoReflect.Descriptor instead.
 func (*GetCapabilitiesRequest) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{38}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GetCapabilitiesRequest) GetInstanceName() string {
@@ -4046,7 +4124,7 @@ type ServerCapabilities struct {
 
 func (x *ServerCapabilities) Reset() {
 	*x = ServerCapabilities{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[39]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4058,7 +4136,7 @@ func (x *ServerCapabilities) String() string {
 func (*ServerCapabilities) ProtoMessage() {}
 
 func (x *ServerCapabilities) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[39]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4071,7 +4149,7 @@ func (x *ServerCapabilities) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerCapabilities.ProtoReflect.Descriptor instead.
 func (*ServerCapabilities) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{39}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ServerCapabilities) GetCacheCapabilities() *CacheCapabilities {
@@ -4119,7 +4197,7 @@ type DigestFunction struct {
 
 func (x *DigestFunction) Reset() {
 	*x = DigestFunction{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[40]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4131,7 +4209,7 @@ func (x *DigestFunction) String() string {
 func (*DigestFunction) ProtoMessage() {}
 
 func (x *DigestFunction) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[40]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4144,7 +4222,7 @@ func (x *DigestFunction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DigestFunction.ProtoReflect.Descriptor instead.
 func (*DigestFunction) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{40}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{41}
 }
 
 // The chunking function is used to split a blob into chunks.
@@ -4165,7 +4243,7 @@ type ChunkingFunction struct {
 
 func (x *ChunkingFunction) Reset() {
 	*x = ChunkingFunction{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[41]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4177,7 +4255,7 @@ func (x *ChunkingFunction) String() string {
 func (*ChunkingFunction) ProtoMessage() {}
 
 func (x *ChunkingFunction) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[41]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4190,7 +4268,7 @@ func (x *ChunkingFunction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChunkingFunction.ProtoReflect.Descriptor instead.
 func (*ChunkingFunction) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{41}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{42}
 }
 
 // Describes the server/instance capabilities for updating the action cache.
@@ -4203,7 +4281,7 @@ type ActionCacheUpdateCapabilities struct {
 
 func (x *ActionCacheUpdateCapabilities) Reset() {
 	*x = ActionCacheUpdateCapabilities{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[42]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4215,7 +4293,7 @@ func (x *ActionCacheUpdateCapabilities) String() string {
 func (*ActionCacheUpdateCapabilities) ProtoMessage() {}
 
 func (x *ActionCacheUpdateCapabilities) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[42]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4228,7 +4306,7 @@ func (x *ActionCacheUpdateCapabilities) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActionCacheUpdateCapabilities.ProtoReflect.Descriptor instead.
 func (*ActionCacheUpdateCapabilities) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{42}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *ActionCacheUpdateCapabilities) GetUpdateEnabled() bool {
@@ -4251,7 +4329,7 @@ type PriorityCapabilities struct {
 
 func (x *PriorityCapabilities) Reset() {
 	*x = PriorityCapabilities{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[43]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4263,7 +4341,7 @@ func (x *PriorityCapabilities) String() string {
 func (*PriorityCapabilities) ProtoMessage() {}
 
 func (x *PriorityCapabilities) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[43]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4276,7 +4354,7 @@ func (x *PriorityCapabilities) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PriorityCapabilities.ProtoReflect.Descriptor instead.
 func (*PriorityCapabilities) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{43}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *PriorityCapabilities) GetPriorities() []*PriorityCapabilities_PriorityRange {
@@ -4295,7 +4373,7 @@ type SymlinkAbsolutePathStrategy struct {
 
 func (x *SymlinkAbsolutePathStrategy) Reset() {
 	*x = SymlinkAbsolutePathStrategy{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[44]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4307,7 +4385,7 @@ func (x *SymlinkAbsolutePathStrategy) String() string {
 func (*SymlinkAbsolutePathStrategy) ProtoMessage() {}
 
 func (x *SymlinkAbsolutePathStrategy) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[44]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4320,7 +4398,7 @@ func (x *SymlinkAbsolutePathStrategy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SymlinkAbsolutePathStrategy.ProtoReflect.Descriptor instead.
 func (*SymlinkAbsolutePathStrategy) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{44}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{45}
 }
 
 // Compression formats which may be supported.
@@ -4332,7 +4410,7 @@ type Compressor struct {
 
 func (x *Compressor) Reset() {
 	*x = Compressor{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[45]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4344,7 +4422,7 @@ func (x *Compressor) String() string {
 func (*Compressor) ProtoMessage() {}
 
 func (x *Compressor) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[45]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4357,7 +4435,7 @@ func (x *Compressor) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Compressor.ProtoReflect.Descriptor instead.
 func (*Compressor) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{45}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{46}
 }
 
 // Capabilities of the remote cache system.
@@ -4422,7 +4500,7 @@ type CacheCapabilities struct {
 
 func (x *CacheCapabilities) Reset() {
 	*x = CacheCapabilities{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[46]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4434,7 +4512,7 @@ func (x *CacheCapabilities) String() string {
 func (*CacheCapabilities) ProtoMessage() {}
 
 func (x *CacheCapabilities) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[46]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4447,7 +4525,7 @@ func (x *CacheCapabilities) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheCapabilities.ProtoReflect.Descriptor instead.
 func (*CacheCapabilities) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{46}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *CacheCapabilities) GetDigestFunctions() []DigestFunction_Value {
@@ -4585,7 +4663,7 @@ type FastCdc2020Params struct {
 
 func (x *FastCdc2020Params) Reset() {
 	*x = FastCdc2020Params{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[47]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4597,7 +4675,7 @@ func (x *FastCdc2020Params) String() string {
 func (*FastCdc2020Params) ProtoMessage() {}
 
 func (x *FastCdc2020Params) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[47]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4610,7 +4688,7 @@ func (x *FastCdc2020Params) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FastCdc2020Params.ProtoReflect.Descriptor instead.
 func (*FastCdc2020Params) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{47}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *FastCdc2020Params) GetAvgChunkSizeBytes() uint64 {
@@ -4668,7 +4746,7 @@ type RepMaxCdcParams struct {
 
 func (x *RepMaxCdcParams) Reset() {
 	*x = RepMaxCdcParams{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[48]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4680,7 +4758,7 @@ func (x *RepMaxCdcParams) String() string {
 func (*RepMaxCdcParams) ProtoMessage() {}
 
 func (x *RepMaxCdcParams) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[48]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4693,7 +4771,7 @@ func (x *RepMaxCdcParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepMaxCdcParams.ProtoReflect.Descriptor instead.
 func (*RepMaxCdcParams) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{48}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *RepMaxCdcParams) GetMinChunkSizeBytes() uint64 {
@@ -4743,7 +4821,7 @@ type ExecutionCapabilities struct {
 
 func (x *ExecutionCapabilities) Reset() {
 	*x = ExecutionCapabilities{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[49]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4755,7 +4833,7 @@ func (x *ExecutionCapabilities) String() string {
 func (*ExecutionCapabilities) ProtoMessage() {}
 
 func (x *ExecutionCapabilities) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[49]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4768,7 +4846,7 @@ func (x *ExecutionCapabilities) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionCapabilities.ProtoReflect.Descriptor instead.
 func (*ExecutionCapabilities) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{49}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *ExecutionCapabilities) GetDigestFunction() DigestFunction_Value {
@@ -4819,7 +4897,7 @@ type ToolDetails struct {
 
 func (x *ToolDetails) Reset() {
 	*x = ToolDetails{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[50]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4831,7 +4909,7 @@ func (x *ToolDetails) String() string {
 func (*ToolDetails) ProtoMessage() {}
 
 func (x *ToolDetails) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[50]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4844,7 +4922,7 @@ func (x *ToolDetails) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ToolDetails.ProtoReflect.Descriptor instead.
 func (*ToolDetails) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{50}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *ToolDetails) GetToolName() string {
@@ -4904,7 +4982,7 @@ type RequestMetadata struct {
 
 func (x *RequestMetadata) Reset() {
 	*x = RequestMetadata{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[51]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4916,7 +4994,7 @@ func (x *RequestMetadata) String() string {
 func (*RequestMetadata) ProtoMessage() {}
 
 func (x *RequestMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[51]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4929,7 +5007,7 @@ func (x *RequestMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequestMetadata.ProtoReflect.Descriptor instead.
 func (*RequestMetadata) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{51}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *RequestMetadata) GetToolDetails() *ToolDetails {
@@ -4995,7 +5073,7 @@ type Command_EnvironmentVariable struct {
 
 func (x *Command_EnvironmentVariable) Reset() {
 	*x = Command_EnvironmentVariable{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[52]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5007,7 +5085,7 @@ func (x *Command_EnvironmentVariable) String() string {
 func (*Command_EnvironmentVariable) ProtoMessage() {}
 
 func (x *Command_EnvironmentVariable) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[52]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5071,7 +5149,7 @@ type Platform_Property struct {
 
 func (x *Platform_Property) Reset() {
 	*x = Platform_Property{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[53]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5083,7 +5161,7 @@ func (x *Platform_Property) String() string {
 func (*Platform_Property) ProtoMessage() {}
 
 func (x *Platform_Property) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[53]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5132,7 +5210,7 @@ type BatchUpdateBlobsRequest_Request struct {
 
 func (x *BatchUpdateBlobsRequest_Request) Reset() {
 	*x = BatchUpdateBlobsRequest_Request{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[55]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5144,7 +5222,7 @@ func (x *BatchUpdateBlobsRequest_Request) String() string {
 func (*BatchUpdateBlobsRequest_Request) ProtoMessage() {}
 
 func (x *BatchUpdateBlobsRequest_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[55]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5194,7 +5272,7 @@ type BatchUpdateBlobsResponse_Response struct {
 
 func (x *BatchUpdateBlobsResponse_Response) Reset() {
 	*x = BatchUpdateBlobsResponse_Response{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[56]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5206,7 +5284,7 @@ func (x *BatchUpdateBlobsResponse_Response) String() string {
 func (*BatchUpdateBlobsResponse_Response) ProtoMessage() {}
 
 func (x *BatchUpdateBlobsResponse_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[56]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5254,7 +5332,7 @@ type BatchReadBlobsResponse_Response struct {
 
 func (x *BatchReadBlobsResponse_Response) Reset() {
 	*x = BatchReadBlobsResponse_Response{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[57]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5266,7 +5344,7 @@ func (x *BatchReadBlobsResponse_Response) String() string {
 func (*BatchReadBlobsResponse_Response) ProtoMessage() {}
 
 func (x *BatchReadBlobsResponse_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[57]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5325,7 +5403,7 @@ type PriorityCapabilities_PriorityRange struct {
 
 func (x *PriorityCapabilities_PriorityRange) Reset() {
 	*x = PriorityCapabilities_PriorityRange{}
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[58]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5337,7 +5415,7 @@ func (x *PriorityCapabilities_PriorityRange) String() string {
 func (*PriorityCapabilities_PriorityRange) ProtoMessage() {}
 
 func (x *PriorityCapabilities_PriorityRange) ProtoReflect() protoreflect.Message {
-	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[58]
+	mi := &file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5350,7 +5428,7 @@ func (x *PriorityCapabilities_PriorityRange) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use PriorityCapabilities_PriorityRange.ProtoReflect.Descriptor instead.
 func (*PriorityCapabilities_PriorityRange) Descriptor() ([]byte, []int) {
-	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{43, 0}
+	return file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP(), []int{44, 0}
 }
 
 func (x *PriorityCapabilities_PriorityRange) GetMinPriority() int32 {
@@ -5587,23 +5665,27 @@ const file_build_bazel_remote_execution_v2_remote_execution_proto_rawDesc = "" +
 	"\x0fdigest_function\x18\x05 \x01(\x0e25.build.bazel.remote.execution.v2.DigestFunction.ValueR\x0edigestFunction\"\x87\x01\n" +
 	"\x0fGetTreeResponse\x12L\n" +
 	"\vdirectories\x18\x01 \x03(\v2*.build.bazel.remote.execution.v2.DirectoryR\vdirectories\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\xc7\x02\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"Y\n" +
+	"\tChunkList\x12L\n" +
+	"\rchunk_digests\x18\x01 \x03(\v2'.build.bazel.remote.execution.v2.DigestR\fchunkDigests\"\xc7\x02\n" +
 	"\x10SplitBlobRequest\x12#\n" +
 	"\rinstance_name\x18\x01 \x01(\tR\finstanceName\x12H\n" +
 	"\vblob_digest\x18\x02 \x01(\v2'.build.bazel.remote.execution.v2.DigestR\n" +
 	"blobDigest\x12^\n" +
 	"\x0fdigest_function\x18\x03 \x01(\x0e25.build.bazel.remote.execution.v2.DigestFunction.ValueR\x0edigestFunction\x12d\n" +
-	"\x11chunking_function\x18\x04 \x01(\x0e27.build.bazel.remote.execution.v2.ChunkingFunction.ValueR\x10chunkingFunction\"\xc7\x01\n" +
+	"\x11chunking_function\x18\x04 \x01(\x0e27.build.bazel.remote.execution.v2.ChunkingFunction.ValueR\x10chunkingFunction\"\xa0\x02\n" +
 	"\x11SplitBlobResponse\x12L\n" +
 	"\rchunk_digests\x18\x01 \x03(\v2'.build.bazel.remote.execution.v2.DigestR\fchunkDigests\x12d\n" +
-	"\x11chunking_function\x18\x02 \x01(\x0e27.build.bazel.remote.execution.v2.ChunkingFunction.ValueR\x10chunkingFunction\"\x96\x03\n" +
+	"\x11chunking_function\x18\x02 \x01(\x0e27.build.bazel.remote.execution.v2.ChunkingFunction.ValueR\x10chunkingFunction\x12W\n" +
+	"\x13indirect_chunk_list\x18\x06 \x01(\v2'.build.bazel.remote.execution.v2.DigestR\x11indirectChunkList\"\xef\x03\n" +
 	"\x11SpliceBlobRequest\x12#\n" +
 	"\rinstance_name\x18\x01 \x01(\tR\finstanceName\x12H\n" +
 	"\vblob_digest\x18\x02 \x01(\v2'.build.bazel.remote.execution.v2.DigestR\n" +
 	"blobDigest\x12L\n" +
 	"\rchunk_digests\x18\x03 \x03(\v2'.build.bazel.remote.execution.v2.DigestR\fchunkDigests\x12^\n" +
 	"\x0fdigest_function\x18\x04 \x01(\x0e25.build.bazel.remote.execution.v2.DigestFunction.ValueR\x0edigestFunction\x12d\n" +
-	"\x11chunking_function\x18\x05 \x01(\x0e27.build.bazel.remote.execution.v2.ChunkingFunction.ValueR\x10chunkingFunction\"^\n" +
+	"\x11chunking_function\x18\x05 \x01(\x0e27.build.bazel.remote.execution.v2.ChunkingFunction.ValueR\x10chunkingFunction\x12W\n" +
+	"\x13indirect_chunk_list\x18\x06 \x01(\v2'.build.bazel.remote.execution.v2.DigestR\x11indirectChunkList\"^\n" +
 	"\x12SpliceBlobResponse\x12H\n" +
 	"\vblob_digest\x18\x01 \x01(\v2'.build.bazel.remote.execution.v2.DigestR\n" +
 	"blobDigest\"=\n" +
@@ -5730,7 +5812,7 @@ func file_build_bazel_remote_execution_v2_remote_execution_proto_rawDescGZIP() [
 }
 
 var file_build_bazel_remote_execution_v2_remote_execution_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes = make([]protoimpl.MessageInfo, 59)
+var file_build_bazel_remote_execution_v2_remote_execution_proto_msgTypes = make([]protoimpl.MessageInfo, 60)
 var file_build_bazel_remote_execution_v2_remote_execution_proto_goTypes = []any{
 	(Command_OutputDirectoryFormat)(0),         // 0: build.bazel.remote.execution.v2.Command.OutputDirectoryFormat
 	(ExecutionStage_Value)(0),                  // 1: build.bazel.remote.execution.v2.ExecutionStage.Value
@@ -5772,70 +5854,71 @@ var file_build_bazel_remote_execution_v2_remote_execution_proto_goTypes = []any{
 	(*BatchReadBlobsResponse)(nil),             // 37: build.bazel.remote.execution.v2.BatchReadBlobsResponse
 	(*GetTreeRequest)(nil),                     // 38: build.bazel.remote.execution.v2.GetTreeRequest
 	(*GetTreeResponse)(nil),                    // 39: build.bazel.remote.execution.v2.GetTreeResponse
-	(*SplitBlobRequest)(nil),                   // 40: build.bazel.remote.execution.v2.SplitBlobRequest
-	(*SplitBlobResponse)(nil),                  // 41: build.bazel.remote.execution.v2.SplitBlobResponse
-	(*SpliceBlobRequest)(nil),                  // 42: build.bazel.remote.execution.v2.SpliceBlobRequest
-	(*SpliceBlobResponse)(nil),                 // 43: build.bazel.remote.execution.v2.SpliceBlobResponse
-	(*GetCapabilitiesRequest)(nil),             // 44: build.bazel.remote.execution.v2.GetCapabilitiesRequest
-	(*ServerCapabilities)(nil),                 // 45: build.bazel.remote.execution.v2.ServerCapabilities
-	(*DigestFunction)(nil),                     // 46: build.bazel.remote.execution.v2.DigestFunction
-	(*ChunkingFunction)(nil),                   // 47: build.bazel.remote.execution.v2.ChunkingFunction
-	(*ActionCacheUpdateCapabilities)(nil),      // 48: build.bazel.remote.execution.v2.ActionCacheUpdateCapabilities
-	(*PriorityCapabilities)(nil),               // 49: build.bazel.remote.execution.v2.PriorityCapabilities
-	(*SymlinkAbsolutePathStrategy)(nil),        // 50: build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy
-	(*Compressor)(nil),                         // 51: build.bazel.remote.execution.v2.Compressor
-	(*CacheCapabilities)(nil),                  // 52: build.bazel.remote.execution.v2.CacheCapabilities
-	(*FastCdc2020Params)(nil),                  // 53: build.bazel.remote.execution.v2.FastCdc2020Params
-	(*RepMaxCdcParams)(nil),                    // 54: build.bazel.remote.execution.v2.RepMaxCdcParams
-	(*ExecutionCapabilities)(nil),              // 55: build.bazel.remote.execution.v2.ExecutionCapabilities
-	(*ToolDetails)(nil),                        // 56: build.bazel.remote.execution.v2.ToolDetails
-	(*RequestMetadata)(nil),                    // 57: build.bazel.remote.execution.v2.RequestMetadata
-	(*Command_EnvironmentVariable)(nil),        // 58: build.bazel.remote.execution.v2.Command.EnvironmentVariable
-	(*Platform_Property)(nil),                  // 59: build.bazel.remote.execution.v2.Platform.Property
-	nil,                                        // 60: build.bazel.remote.execution.v2.ExecuteResponse.ServerLogsEntry
-	(*BatchUpdateBlobsRequest_Request)(nil),    // 61: build.bazel.remote.execution.v2.BatchUpdateBlobsRequest.Request
-	(*BatchUpdateBlobsResponse_Response)(nil),  // 62: build.bazel.remote.execution.v2.BatchUpdateBlobsResponse.Response
-	(*BatchReadBlobsResponse_Response)(nil),    // 63: build.bazel.remote.execution.v2.BatchReadBlobsResponse.Response
-	(*PriorityCapabilities_PriorityRange)(nil), // 64: build.bazel.remote.execution.v2.PriorityCapabilities.PriorityRange
-	(*durationpb.Duration)(nil),                // 65: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),              // 66: google.protobuf.Timestamp
-	(*wrapperspb.UInt32Value)(nil),             // 67: google.protobuf.UInt32Value
-	(*anypb.Any)(nil),                          // 68: google.protobuf.Any
-	(*status.Status)(nil),                      // 69: google.rpc.Status
-	(*semver.SemVer)(nil),                      // 70: build.bazel.semver.SemVer
-	(*longrunningpb.Operation)(nil),            // 71: google.longrunning.Operation
+	(*ChunkList)(nil),                          // 40: build.bazel.remote.execution.v2.ChunkList
+	(*SplitBlobRequest)(nil),                   // 41: build.bazel.remote.execution.v2.SplitBlobRequest
+	(*SplitBlobResponse)(nil),                  // 42: build.bazel.remote.execution.v2.SplitBlobResponse
+	(*SpliceBlobRequest)(nil),                  // 43: build.bazel.remote.execution.v2.SpliceBlobRequest
+	(*SpliceBlobResponse)(nil),                 // 44: build.bazel.remote.execution.v2.SpliceBlobResponse
+	(*GetCapabilitiesRequest)(nil),             // 45: build.bazel.remote.execution.v2.GetCapabilitiesRequest
+	(*ServerCapabilities)(nil),                 // 46: build.bazel.remote.execution.v2.ServerCapabilities
+	(*DigestFunction)(nil),                     // 47: build.bazel.remote.execution.v2.DigestFunction
+	(*ChunkingFunction)(nil),                   // 48: build.bazel.remote.execution.v2.ChunkingFunction
+	(*ActionCacheUpdateCapabilities)(nil),      // 49: build.bazel.remote.execution.v2.ActionCacheUpdateCapabilities
+	(*PriorityCapabilities)(nil),               // 50: build.bazel.remote.execution.v2.PriorityCapabilities
+	(*SymlinkAbsolutePathStrategy)(nil),        // 51: build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy
+	(*Compressor)(nil),                         // 52: build.bazel.remote.execution.v2.Compressor
+	(*CacheCapabilities)(nil),                  // 53: build.bazel.remote.execution.v2.CacheCapabilities
+	(*FastCdc2020Params)(nil),                  // 54: build.bazel.remote.execution.v2.FastCdc2020Params
+	(*RepMaxCdcParams)(nil),                    // 55: build.bazel.remote.execution.v2.RepMaxCdcParams
+	(*ExecutionCapabilities)(nil),              // 56: build.bazel.remote.execution.v2.ExecutionCapabilities
+	(*ToolDetails)(nil),                        // 57: build.bazel.remote.execution.v2.ToolDetails
+	(*RequestMetadata)(nil),                    // 58: build.bazel.remote.execution.v2.RequestMetadata
+	(*Command_EnvironmentVariable)(nil),        // 59: build.bazel.remote.execution.v2.Command.EnvironmentVariable
+	(*Platform_Property)(nil),                  // 60: build.bazel.remote.execution.v2.Platform.Property
+	nil,                                        // 61: build.bazel.remote.execution.v2.ExecuteResponse.ServerLogsEntry
+	(*BatchUpdateBlobsRequest_Request)(nil),    // 62: build.bazel.remote.execution.v2.BatchUpdateBlobsRequest.Request
+	(*BatchUpdateBlobsResponse_Response)(nil),  // 63: build.bazel.remote.execution.v2.BatchUpdateBlobsResponse.Response
+	(*BatchReadBlobsResponse_Response)(nil),    // 64: build.bazel.remote.execution.v2.BatchReadBlobsResponse.Response
+	(*PriorityCapabilities_PriorityRange)(nil), // 65: build.bazel.remote.execution.v2.PriorityCapabilities.PriorityRange
+	(*durationpb.Duration)(nil),                // 66: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),              // 67: google.protobuf.Timestamp
+	(*wrapperspb.UInt32Value)(nil),             // 68: google.protobuf.UInt32Value
+	(*anypb.Any)(nil),                          // 69: google.protobuf.Any
+	(*status.Status)(nil),                      // 70: google.rpc.Status
+	(*semver.SemVer)(nil),                      // 71: build.bazel.semver.SemVer
+	(*longrunningpb.Operation)(nil),            // 72: google.longrunning.Operation
 }
 var file_build_bazel_remote_execution_v2_remote_execution_proto_depIdxs = []int32{
 	15,  // 0: build.bazel.remote.execution.v2.Action.command_digest:type_name -> build.bazel.remote.execution.v2.Digest
 	15,  // 1: build.bazel.remote.execution.v2.Action.input_root_digest:type_name -> build.bazel.remote.execution.v2.Digest
-	65,  // 2: build.bazel.remote.execution.v2.Action.timeout:type_name -> google.protobuf.Duration
+	66,  // 2: build.bazel.remote.execution.v2.Action.timeout:type_name -> google.protobuf.Duration
 	8,   // 3: build.bazel.remote.execution.v2.Action.platform:type_name -> build.bazel.remote.execution.v2.Platform
-	58,  // 4: build.bazel.remote.execution.v2.Command.environment_variables:type_name -> build.bazel.remote.execution.v2.Command.EnvironmentVariable
+	59,  // 4: build.bazel.remote.execution.v2.Command.environment_variables:type_name -> build.bazel.remote.execution.v2.Command.EnvironmentVariable
 	8,   // 5: build.bazel.remote.execution.v2.Command.platform:type_name -> build.bazel.remote.execution.v2.Platform
 	0,   // 6: build.bazel.remote.execution.v2.Command.output_directory_format:type_name -> build.bazel.remote.execution.v2.Command.OutputDirectoryFormat
-	59,  // 7: build.bazel.remote.execution.v2.Platform.properties:type_name -> build.bazel.remote.execution.v2.Platform.Property
+	60,  // 7: build.bazel.remote.execution.v2.Platform.properties:type_name -> build.bazel.remote.execution.v2.Platform.Property
 	12,  // 8: build.bazel.remote.execution.v2.Directory.files:type_name -> build.bazel.remote.execution.v2.FileNode
 	13,  // 9: build.bazel.remote.execution.v2.Directory.directories:type_name -> build.bazel.remote.execution.v2.DirectoryNode
 	14,  // 10: build.bazel.remote.execution.v2.Directory.symlinks:type_name -> build.bazel.remote.execution.v2.SymlinkNode
 	11,  // 11: build.bazel.remote.execution.v2.Directory.node_properties:type_name -> build.bazel.remote.execution.v2.NodeProperties
 	10,  // 12: build.bazel.remote.execution.v2.NodeProperties.properties:type_name -> build.bazel.remote.execution.v2.NodeProperty
-	66,  // 13: build.bazel.remote.execution.v2.NodeProperties.mtime:type_name -> google.protobuf.Timestamp
-	67,  // 14: build.bazel.remote.execution.v2.NodeProperties.unix_mode:type_name -> google.protobuf.UInt32Value
+	67,  // 13: build.bazel.remote.execution.v2.NodeProperties.mtime:type_name -> google.protobuf.Timestamp
+	68,  // 14: build.bazel.remote.execution.v2.NodeProperties.unix_mode:type_name -> google.protobuf.UInt32Value
 	15,  // 15: build.bazel.remote.execution.v2.FileNode.digest:type_name -> build.bazel.remote.execution.v2.Digest
 	11,  // 16: build.bazel.remote.execution.v2.FileNode.node_properties:type_name -> build.bazel.remote.execution.v2.NodeProperties
 	15,  // 17: build.bazel.remote.execution.v2.DirectoryNode.digest:type_name -> build.bazel.remote.execution.v2.Digest
 	11,  // 18: build.bazel.remote.execution.v2.SymlinkNode.node_properties:type_name -> build.bazel.remote.execution.v2.NodeProperties
-	66,  // 19: build.bazel.remote.execution.v2.ExecutedActionMetadata.queued_timestamp:type_name -> google.protobuf.Timestamp
-	66,  // 20: build.bazel.remote.execution.v2.ExecutedActionMetadata.worker_start_timestamp:type_name -> google.protobuf.Timestamp
-	66,  // 21: build.bazel.remote.execution.v2.ExecutedActionMetadata.worker_completed_timestamp:type_name -> google.protobuf.Timestamp
-	66,  // 22: build.bazel.remote.execution.v2.ExecutedActionMetadata.input_fetch_start_timestamp:type_name -> google.protobuf.Timestamp
-	66,  // 23: build.bazel.remote.execution.v2.ExecutedActionMetadata.input_fetch_completed_timestamp:type_name -> google.protobuf.Timestamp
-	66,  // 24: build.bazel.remote.execution.v2.ExecutedActionMetadata.execution_start_timestamp:type_name -> google.protobuf.Timestamp
-	66,  // 25: build.bazel.remote.execution.v2.ExecutedActionMetadata.execution_completed_timestamp:type_name -> google.protobuf.Timestamp
-	65,  // 26: build.bazel.remote.execution.v2.ExecutedActionMetadata.virtual_execution_duration:type_name -> google.protobuf.Duration
-	66,  // 27: build.bazel.remote.execution.v2.ExecutedActionMetadata.output_upload_start_timestamp:type_name -> google.protobuf.Timestamp
-	66,  // 28: build.bazel.remote.execution.v2.ExecutedActionMetadata.output_upload_completed_timestamp:type_name -> google.protobuf.Timestamp
-	68,  // 29: build.bazel.remote.execution.v2.ExecutedActionMetadata.auxiliary_metadata:type_name -> google.protobuf.Any
+	67,  // 19: build.bazel.remote.execution.v2.ExecutedActionMetadata.queued_timestamp:type_name -> google.protobuf.Timestamp
+	67,  // 20: build.bazel.remote.execution.v2.ExecutedActionMetadata.worker_start_timestamp:type_name -> google.protobuf.Timestamp
+	67,  // 21: build.bazel.remote.execution.v2.ExecutedActionMetadata.worker_completed_timestamp:type_name -> google.protobuf.Timestamp
+	67,  // 22: build.bazel.remote.execution.v2.ExecutedActionMetadata.input_fetch_start_timestamp:type_name -> google.protobuf.Timestamp
+	67,  // 23: build.bazel.remote.execution.v2.ExecutedActionMetadata.input_fetch_completed_timestamp:type_name -> google.protobuf.Timestamp
+	67,  // 24: build.bazel.remote.execution.v2.ExecutedActionMetadata.execution_start_timestamp:type_name -> google.protobuf.Timestamp
+	67,  // 25: build.bazel.remote.execution.v2.ExecutedActionMetadata.execution_completed_timestamp:type_name -> google.protobuf.Timestamp
+	66,  // 26: build.bazel.remote.execution.v2.ExecutedActionMetadata.virtual_execution_duration:type_name -> google.protobuf.Duration
+	67,  // 27: build.bazel.remote.execution.v2.ExecutedActionMetadata.output_upload_start_timestamp:type_name -> google.protobuf.Timestamp
+	67,  // 28: build.bazel.remote.execution.v2.ExecutedActionMetadata.output_upload_completed_timestamp:type_name -> google.protobuf.Timestamp
+	69,  // 29: build.bazel.remote.execution.v2.ExecutedActionMetadata.auxiliary_metadata:type_name -> google.protobuf.Any
 	18,  // 30: build.bazel.remote.execution.v2.ActionResult.output_files:type_name -> build.bazel.remote.execution.v2.OutputFile
 	21,  // 31: build.bazel.remote.execution.v2.ActionResult.output_file_symlinks:type_name -> build.bazel.remote.execution.v2.OutputSymlink
 	21,  // 32: build.bazel.remote.execution.v2.ActionResult.output_symlinks:type_name -> build.bazel.remote.execution.v2.OutputSymlink
@@ -5857,8 +5940,8 @@ var file_build_bazel_remote_execution_v2_remote_execution_proto_depIdxs = []int3
 	2,   // 48: build.bazel.remote.execution.v2.ExecuteRequest.digest_function:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
 	15,  // 49: build.bazel.remote.execution.v2.LogFile.digest:type_name -> build.bazel.remote.execution.v2.Digest
 	17,  // 50: build.bazel.remote.execution.v2.ExecuteResponse.result:type_name -> build.bazel.remote.execution.v2.ActionResult
-	69,  // 51: build.bazel.remote.execution.v2.ExecuteResponse.status:type_name -> google.rpc.Status
-	60,  // 52: build.bazel.remote.execution.v2.ExecuteResponse.server_logs:type_name -> build.bazel.remote.execution.v2.ExecuteResponse.ServerLogsEntry
+	70,  // 51: build.bazel.remote.execution.v2.ExecuteResponse.status:type_name -> google.rpc.Status
+	61,  // 52: build.bazel.remote.execution.v2.ExecuteResponse.server_logs:type_name -> build.bazel.remote.execution.v2.ExecuteResponse.ServerLogsEntry
 	1,   // 53: build.bazel.remote.execution.v2.ExecuteOperationMetadata.stage:type_name -> build.bazel.remote.execution.v2.ExecutionStage.Value
 	15,  // 54: build.bazel.remote.execution.v2.ExecuteOperationMetadata.action_digest:type_name -> build.bazel.remote.execution.v2.Digest
 	16,  // 55: build.bazel.remote.execution.v2.ExecuteOperationMetadata.partial_execution_metadata:type_name -> build.bazel.remote.execution.v2.ExecutedActionMetadata
@@ -5872,79 +5955,82 @@ var file_build_bazel_remote_execution_v2_remote_execution_proto_depIdxs = []int3
 	15,  // 63: build.bazel.remote.execution.v2.FindMissingBlobsRequest.blob_digests:type_name -> build.bazel.remote.execution.v2.Digest
 	2,   // 64: build.bazel.remote.execution.v2.FindMissingBlobsRequest.digest_function:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
 	15,  // 65: build.bazel.remote.execution.v2.FindMissingBlobsResponse.missing_blob_digests:type_name -> build.bazel.remote.execution.v2.Digest
-	61,  // 66: build.bazel.remote.execution.v2.BatchUpdateBlobsRequest.requests:type_name -> build.bazel.remote.execution.v2.BatchUpdateBlobsRequest.Request
+	62,  // 66: build.bazel.remote.execution.v2.BatchUpdateBlobsRequest.requests:type_name -> build.bazel.remote.execution.v2.BatchUpdateBlobsRequest.Request
 	2,   // 67: build.bazel.remote.execution.v2.BatchUpdateBlobsRequest.digest_function:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
-	62,  // 68: build.bazel.remote.execution.v2.BatchUpdateBlobsResponse.responses:type_name -> build.bazel.remote.execution.v2.BatchUpdateBlobsResponse.Response
+	63,  // 68: build.bazel.remote.execution.v2.BatchUpdateBlobsResponse.responses:type_name -> build.bazel.remote.execution.v2.BatchUpdateBlobsResponse.Response
 	15,  // 69: build.bazel.remote.execution.v2.BatchReadBlobsRequest.digests:type_name -> build.bazel.remote.execution.v2.Digest
 	5,   // 70: build.bazel.remote.execution.v2.BatchReadBlobsRequest.acceptable_compressors:type_name -> build.bazel.remote.execution.v2.Compressor.Value
 	2,   // 71: build.bazel.remote.execution.v2.BatchReadBlobsRequest.digest_function:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
-	63,  // 72: build.bazel.remote.execution.v2.BatchReadBlobsResponse.responses:type_name -> build.bazel.remote.execution.v2.BatchReadBlobsResponse.Response
+	64,  // 72: build.bazel.remote.execution.v2.BatchReadBlobsResponse.responses:type_name -> build.bazel.remote.execution.v2.BatchReadBlobsResponse.Response
 	15,  // 73: build.bazel.remote.execution.v2.GetTreeRequest.root_digest:type_name -> build.bazel.remote.execution.v2.Digest
 	2,   // 74: build.bazel.remote.execution.v2.GetTreeRequest.digest_function:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
 	9,   // 75: build.bazel.remote.execution.v2.GetTreeResponse.directories:type_name -> build.bazel.remote.execution.v2.Directory
-	15,  // 76: build.bazel.remote.execution.v2.SplitBlobRequest.blob_digest:type_name -> build.bazel.remote.execution.v2.Digest
-	2,   // 77: build.bazel.remote.execution.v2.SplitBlobRequest.digest_function:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
-	3,   // 78: build.bazel.remote.execution.v2.SplitBlobRequest.chunking_function:type_name -> build.bazel.remote.execution.v2.ChunkingFunction.Value
-	15,  // 79: build.bazel.remote.execution.v2.SplitBlobResponse.chunk_digests:type_name -> build.bazel.remote.execution.v2.Digest
-	3,   // 80: build.bazel.remote.execution.v2.SplitBlobResponse.chunking_function:type_name -> build.bazel.remote.execution.v2.ChunkingFunction.Value
-	15,  // 81: build.bazel.remote.execution.v2.SpliceBlobRequest.blob_digest:type_name -> build.bazel.remote.execution.v2.Digest
-	15,  // 82: build.bazel.remote.execution.v2.SpliceBlobRequest.chunk_digests:type_name -> build.bazel.remote.execution.v2.Digest
-	2,   // 83: build.bazel.remote.execution.v2.SpliceBlobRequest.digest_function:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
-	3,   // 84: build.bazel.remote.execution.v2.SpliceBlobRequest.chunking_function:type_name -> build.bazel.remote.execution.v2.ChunkingFunction.Value
-	15,  // 85: build.bazel.remote.execution.v2.SpliceBlobResponse.blob_digest:type_name -> build.bazel.remote.execution.v2.Digest
-	52,  // 86: build.bazel.remote.execution.v2.ServerCapabilities.cache_capabilities:type_name -> build.bazel.remote.execution.v2.CacheCapabilities
-	55,  // 87: build.bazel.remote.execution.v2.ServerCapabilities.execution_capabilities:type_name -> build.bazel.remote.execution.v2.ExecutionCapabilities
-	70,  // 88: build.bazel.remote.execution.v2.ServerCapabilities.deprecated_api_version:type_name -> build.bazel.semver.SemVer
-	70,  // 89: build.bazel.remote.execution.v2.ServerCapabilities.low_api_version:type_name -> build.bazel.semver.SemVer
-	70,  // 90: build.bazel.remote.execution.v2.ServerCapabilities.high_api_version:type_name -> build.bazel.semver.SemVer
-	64,  // 91: build.bazel.remote.execution.v2.PriorityCapabilities.priorities:type_name -> build.bazel.remote.execution.v2.PriorityCapabilities.PriorityRange
-	2,   // 92: build.bazel.remote.execution.v2.CacheCapabilities.digest_functions:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
-	48,  // 93: build.bazel.remote.execution.v2.CacheCapabilities.action_cache_update_capabilities:type_name -> build.bazel.remote.execution.v2.ActionCacheUpdateCapabilities
-	49,  // 94: build.bazel.remote.execution.v2.CacheCapabilities.cache_priority_capabilities:type_name -> build.bazel.remote.execution.v2.PriorityCapabilities
-	4,   // 95: build.bazel.remote.execution.v2.CacheCapabilities.symlink_absolute_path_strategy:type_name -> build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy.Value
-	5,   // 96: build.bazel.remote.execution.v2.CacheCapabilities.supported_compressors:type_name -> build.bazel.remote.execution.v2.Compressor.Value
-	5,   // 97: build.bazel.remote.execution.v2.CacheCapabilities.supported_batch_update_compressors:type_name -> build.bazel.remote.execution.v2.Compressor.Value
-	53,  // 98: build.bazel.remote.execution.v2.CacheCapabilities.fast_cdc_2020_params:type_name -> build.bazel.remote.execution.v2.FastCdc2020Params
-	54,  // 99: build.bazel.remote.execution.v2.CacheCapabilities.rep_max_cdc_params:type_name -> build.bazel.remote.execution.v2.RepMaxCdcParams
-	2,   // 100: build.bazel.remote.execution.v2.ExecutionCapabilities.digest_function:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
-	49,  // 101: build.bazel.remote.execution.v2.ExecutionCapabilities.execution_priority_capabilities:type_name -> build.bazel.remote.execution.v2.PriorityCapabilities
-	2,   // 102: build.bazel.remote.execution.v2.ExecutionCapabilities.digest_functions:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
-	56,  // 103: build.bazel.remote.execution.v2.RequestMetadata.tool_details:type_name -> build.bazel.remote.execution.v2.ToolDetails
-	25,  // 104: build.bazel.remote.execution.v2.ExecuteResponse.ServerLogsEntry.value:type_name -> build.bazel.remote.execution.v2.LogFile
-	15,  // 105: build.bazel.remote.execution.v2.BatchUpdateBlobsRequest.Request.digest:type_name -> build.bazel.remote.execution.v2.Digest
-	5,   // 106: build.bazel.remote.execution.v2.BatchUpdateBlobsRequest.Request.compressor:type_name -> build.bazel.remote.execution.v2.Compressor.Value
-	15,  // 107: build.bazel.remote.execution.v2.BatchUpdateBlobsResponse.Response.digest:type_name -> build.bazel.remote.execution.v2.Digest
-	69,  // 108: build.bazel.remote.execution.v2.BatchUpdateBlobsResponse.Response.status:type_name -> google.rpc.Status
-	15,  // 109: build.bazel.remote.execution.v2.BatchReadBlobsResponse.Response.digest:type_name -> build.bazel.remote.execution.v2.Digest
-	5,   // 110: build.bazel.remote.execution.v2.BatchReadBlobsResponse.Response.compressor:type_name -> build.bazel.remote.execution.v2.Compressor.Value
-	69,  // 111: build.bazel.remote.execution.v2.BatchReadBlobsResponse.Response.status:type_name -> google.rpc.Status
-	24,  // 112: build.bazel.remote.execution.v2.Execution.Execute:input_type -> build.bazel.remote.execution.v2.ExecuteRequest
-	29,  // 113: build.bazel.remote.execution.v2.Execution.WaitExecution:input_type -> build.bazel.remote.execution.v2.WaitExecutionRequest
-	30,  // 114: build.bazel.remote.execution.v2.ActionCache.GetActionResult:input_type -> build.bazel.remote.execution.v2.GetActionResultRequest
-	31,  // 115: build.bazel.remote.execution.v2.ActionCache.UpdateActionResult:input_type -> build.bazel.remote.execution.v2.UpdateActionResultRequest
-	32,  // 116: build.bazel.remote.execution.v2.ContentAddressableStorage.FindMissingBlobs:input_type -> build.bazel.remote.execution.v2.FindMissingBlobsRequest
-	34,  // 117: build.bazel.remote.execution.v2.ContentAddressableStorage.BatchUpdateBlobs:input_type -> build.bazel.remote.execution.v2.BatchUpdateBlobsRequest
-	36,  // 118: build.bazel.remote.execution.v2.ContentAddressableStorage.BatchReadBlobs:input_type -> build.bazel.remote.execution.v2.BatchReadBlobsRequest
-	38,  // 119: build.bazel.remote.execution.v2.ContentAddressableStorage.GetTree:input_type -> build.bazel.remote.execution.v2.GetTreeRequest
-	40,  // 120: build.bazel.remote.execution.v2.ContentAddressableStorage.SplitBlob:input_type -> build.bazel.remote.execution.v2.SplitBlobRequest
-	42,  // 121: build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceBlob:input_type -> build.bazel.remote.execution.v2.SpliceBlobRequest
-	44,  // 122: build.bazel.remote.execution.v2.Capabilities.GetCapabilities:input_type -> build.bazel.remote.execution.v2.GetCapabilitiesRequest
-	71,  // 123: build.bazel.remote.execution.v2.Execution.Execute:output_type -> google.longrunning.Operation
-	71,  // 124: build.bazel.remote.execution.v2.Execution.WaitExecution:output_type -> google.longrunning.Operation
-	17,  // 125: build.bazel.remote.execution.v2.ActionCache.GetActionResult:output_type -> build.bazel.remote.execution.v2.ActionResult
-	17,  // 126: build.bazel.remote.execution.v2.ActionCache.UpdateActionResult:output_type -> build.bazel.remote.execution.v2.ActionResult
-	33,  // 127: build.bazel.remote.execution.v2.ContentAddressableStorage.FindMissingBlobs:output_type -> build.bazel.remote.execution.v2.FindMissingBlobsResponse
-	35,  // 128: build.bazel.remote.execution.v2.ContentAddressableStorage.BatchUpdateBlobs:output_type -> build.bazel.remote.execution.v2.BatchUpdateBlobsResponse
-	37,  // 129: build.bazel.remote.execution.v2.ContentAddressableStorage.BatchReadBlobs:output_type -> build.bazel.remote.execution.v2.BatchReadBlobsResponse
-	39,  // 130: build.bazel.remote.execution.v2.ContentAddressableStorage.GetTree:output_type -> build.bazel.remote.execution.v2.GetTreeResponse
-	41,  // 131: build.bazel.remote.execution.v2.ContentAddressableStorage.SplitBlob:output_type -> build.bazel.remote.execution.v2.SplitBlobResponse
-	43,  // 132: build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceBlob:output_type -> build.bazel.remote.execution.v2.SpliceBlobResponse
-	45,  // 133: build.bazel.remote.execution.v2.Capabilities.GetCapabilities:output_type -> build.bazel.remote.execution.v2.ServerCapabilities
-	123, // [123:134] is the sub-list for method output_type
-	112, // [112:123] is the sub-list for method input_type
-	112, // [112:112] is the sub-list for extension type_name
-	112, // [112:112] is the sub-list for extension extendee
-	0,   // [0:112] is the sub-list for field type_name
+	15,  // 76: build.bazel.remote.execution.v2.ChunkList.chunk_digests:type_name -> build.bazel.remote.execution.v2.Digest
+	15,  // 77: build.bazel.remote.execution.v2.SplitBlobRequest.blob_digest:type_name -> build.bazel.remote.execution.v2.Digest
+	2,   // 78: build.bazel.remote.execution.v2.SplitBlobRequest.digest_function:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
+	3,   // 79: build.bazel.remote.execution.v2.SplitBlobRequest.chunking_function:type_name -> build.bazel.remote.execution.v2.ChunkingFunction.Value
+	15,  // 80: build.bazel.remote.execution.v2.SplitBlobResponse.chunk_digests:type_name -> build.bazel.remote.execution.v2.Digest
+	3,   // 81: build.bazel.remote.execution.v2.SplitBlobResponse.chunking_function:type_name -> build.bazel.remote.execution.v2.ChunkingFunction.Value
+	15,  // 82: build.bazel.remote.execution.v2.SplitBlobResponse.indirect_chunk_list:type_name -> build.bazel.remote.execution.v2.Digest
+	15,  // 83: build.bazel.remote.execution.v2.SpliceBlobRequest.blob_digest:type_name -> build.bazel.remote.execution.v2.Digest
+	15,  // 84: build.bazel.remote.execution.v2.SpliceBlobRequest.chunk_digests:type_name -> build.bazel.remote.execution.v2.Digest
+	2,   // 85: build.bazel.remote.execution.v2.SpliceBlobRequest.digest_function:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
+	3,   // 86: build.bazel.remote.execution.v2.SpliceBlobRequest.chunking_function:type_name -> build.bazel.remote.execution.v2.ChunkingFunction.Value
+	15,  // 87: build.bazel.remote.execution.v2.SpliceBlobRequest.indirect_chunk_list:type_name -> build.bazel.remote.execution.v2.Digest
+	15,  // 88: build.bazel.remote.execution.v2.SpliceBlobResponse.blob_digest:type_name -> build.bazel.remote.execution.v2.Digest
+	53,  // 89: build.bazel.remote.execution.v2.ServerCapabilities.cache_capabilities:type_name -> build.bazel.remote.execution.v2.CacheCapabilities
+	56,  // 90: build.bazel.remote.execution.v2.ServerCapabilities.execution_capabilities:type_name -> build.bazel.remote.execution.v2.ExecutionCapabilities
+	71,  // 91: build.bazel.remote.execution.v2.ServerCapabilities.deprecated_api_version:type_name -> build.bazel.semver.SemVer
+	71,  // 92: build.bazel.remote.execution.v2.ServerCapabilities.low_api_version:type_name -> build.bazel.semver.SemVer
+	71,  // 93: build.bazel.remote.execution.v2.ServerCapabilities.high_api_version:type_name -> build.bazel.semver.SemVer
+	65,  // 94: build.bazel.remote.execution.v2.PriorityCapabilities.priorities:type_name -> build.bazel.remote.execution.v2.PriorityCapabilities.PriorityRange
+	2,   // 95: build.bazel.remote.execution.v2.CacheCapabilities.digest_functions:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
+	49,  // 96: build.bazel.remote.execution.v2.CacheCapabilities.action_cache_update_capabilities:type_name -> build.bazel.remote.execution.v2.ActionCacheUpdateCapabilities
+	50,  // 97: build.bazel.remote.execution.v2.CacheCapabilities.cache_priority_capabilities:type_name -> build.bazel.remote.execution.v2.PriorityCapabilities
+	4,   // 98: build.bazel.remote.execution.v2.CacheCapabilities.symlink_absolute_path_strategy:type_name -> build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy.Value
+	5,   // 99: build.bazel.remote.execution.v2.CacheCapabilities.supported_compressors:type_name -> build.bazel.remote.execution.v2.Compressor.Value
+	5,   // 100: build.bazel.remote.execution.v2.CacheCapabilities.supported_batch_update_compressors:type_name -> build.bazel.remote.execution.v2.Compressor.Value
+	54,  // 101: build.bazel.remote.execution.v2.CacheCapabilities.fast_cdc_2020_params:type_name -> build.bazel.remote.execution.v2.FastCdc2020Params
+	55,  // 102: build.bazel.remote.execution.v2.CacheCapabilities.rep_max_cdc_params:type_name -> build.bazel.remote.execution.v2.RepMaxCdcParams
+	2,   // 103: build.bazel.remote.execution.v2.ExecutionCapabilities.digest_function:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
+	50,  // 104: build.bazel.remote.execution.v2.ExecutionCapabilities.execution_priority_capabilities:type_name -> build.bazel.remote.execution.v2.PriorityCapabilities
+	2,   // 105: build.bazel.remote.execution.v2.ExecutionCapabilities.digest_functions:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
+	57,  // 106: build.bazel.remote.execution.v2.RequestMetadata.tool_details:type_name -> build.bazel.remote.execution.v2.ToolDetails
+	25,  // 107: build.bazel.remote.execution.v2.ExecuteResponse.ServerLogsEntry.value:type_name -> build.bazel.remote.execution.v2.LogFile
+	15,  // 108: build.bazel.remote.execution.v2.BatchUpdateBlobsRequest.Request.digest:type_name -> build.bazel.remote.execution.v2.Digest
+	5,   // 109: build.bazel.remote.execution.v2.BatchUpdateBlobsRequest.Request.compressor:type_name -> build.bazel.remote.execution.v2.Compressor.Value
+	15,  // 110: build.bazel.remote.execution.v2.BatchUpdateBlobsResponse.Response.digest:type_name -> build.bazel.remote.execution.v2.Digest
+	70,  // 111: build.bazel.remote.execution.v2.BatchUpdateBlobsResponse.Response.status:type_name -> google.rpc.Status
+	15,  // 112: build.bazel.remote.execution.v2.BatchReadBlobsResponse.Response.digest:type_name -> build.bazel.remote.execution.v2.Digest
+	5,   // 113: build.bazel.remote.execution.v2.BatchReadBlobsResponse.Response.compressor:type_name -> build.bazel.remote.execution.v2.Compressor.Value
+	70,  // 114: build.bazel.remote.execution.v2.BatchReadBlobsResponse.Response.status:type_name -> google.rpc.Status
+	24,  // 115: build.bazel.remote.execution.v2.Execution.Execute:input_type -> build.bazel.remote.execution.v2.ExecuteRequest
+	29,  // 116: build.bazel.remote.execution.v2.Execution.WaitExecution:input_type -> build.bazel.remote.execution.v2.WaitExecutionRequest
+	30,  // 117: build.bazel.remote.execution.v2.ActionCache.GetActionResult:input_type -> build.bazel.remote.execution.v2.GetActionResultRequest
+	31,  // 118: build.bazel.remote.execution.v2.ActionCache.UpdateActionResult:input_type -> build.bazel.remote.execution.v2.UpdateActionResultRequest
+	32,  // 119: build.bazel.remote.execution.v2.ContentAddressableStorage.FindMissingBlobs:input_type -> build.bazel.remote.execution.v2.FindMissingBlobsRequest
+	34,  // 120: build.bazel.remote.execution.v2.ContentAddressableStorage.BatchUpdateBlobs:input_type -> build.bazel.remote.execution.v2.BatchUpdateBlobsRequest
+	36,  // 121: build.bazel.remote.execution.v2.ContentAddressableStorage.BatchReadBlobs:input_type -> build.bazel.remote.execution.v2.BatchReadBlobsRequest
+	38,  // 122: build.bazel.remote.execution.v2.ContentAddressableStorage.GetTree:input_type -> build.bazel.remote.execution.v2.GetTreeRequest
+	41,  // 123: build.bazel.remote.execution.v2.ContentAddressableStorage.SplitBlob:input_type -> build.bazel.remote.execution.v2.SplitBlobRequest
+	43,  // 124: build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceBlob:input_type -> build.bazel.remote.execution.v2.SpliceBlobRequest
+	45,  // 125: build.bazel.remote.execution.v2.Capabilities.GetCapabilities:input_type -> build.bazel.remote.execution.v2.GetCapabilitiesRequest
+	72,  // 126: build.bazel.remote.execution.v2.Execution.Execute:output_type -> google.longrunning.Operation
+	72,  // 127: build.bazel.remote.execution.v2.Execution.WaitExecution:output_type -> google.longrunning.Operation
+	17,  // 128: build.bazel.remote.execution.v2.ActionCache.GetActionResult:output_type -> build.bazel.remote.execution.v2.ActionResult
+	17,  // 129: build.bazel.remote.execution.v2.ActionCache.UpdateActionResult:output_type -> build.bazel.remote.execution.v2.ActionResult
+	33,  // 130: build.bazel.remote.execution.v2.ContentAddressableStorage.FindMissingBlobs:output_type -> build.bazel.remote.execution.v2.FindMissingBlobsResponse
+	35,  // 131: build.bazel.remote.execution.v2.ContentAddressableStorage.BatchUpdateBlobs:output_type -> build.bazel.remote.execution.v2.BatchUpdateBlobsResponse
+	37,  // 132: build.bazel.remote.execution.v2.ContentAddressableStorage.BatchReadBlobs:output_type -> build.bazel.remote.execution.v2.BatchReadBlobsResponse
+	39,  // 133: build.bazel.remote.execution.v2.ContentAddressableStorage.GetTree:output_type -> build.bazel.remote.execution.v2.GetTreeResponse
+	42,  // 134: build.bazel.remote.execution.v2.ContentAddressableStorage.SplitBlob:output_type -> build.bazel.remote.execution.v2.SplitBlobResponse
+	44,  // 135: build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceBlob:output_type -> build.bazel.remote.execution.v2.SpliceBlobResponse
+	46,  // 136: build.bazel.remote.execution.v2.Capabilities.GetCapabilities:output_type -> build.bazel.remote.execution.v2.ServerCapabilities
+	126, // [126:137] is the sub-list for method output_type
+	115, // [115:126] is the sub-list for method input_type
+	115, // [115:115] is the sub-list for extension type_name
+	115, // [115:115] is the sub-list for extension extendee
+	0,   // [0:115] is the sub-list for field type_name
 }
 
 func init() { file_build_bazel_remote_execution_v2_remote_execution_proto_init() }
@@ -5958,7 +6044,7 @@ func file_build_bazel_remote_execution_v2_remote_execution_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_build_bazel_remote_execution_v2_remote_execution_proto_rawDesc), len(file_build_bazel_remote_execution_v2_remote_execution_proto_rawDesc)),
 			NumEnums:      6,
-			NumMessages:   59,
+			NumMessages:   60,
 			NumExtensions: 0,
 			NumServices:   4,
 		},

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -545,11 +545,14 @@ service ContentAddressableStorage {
   //
   // Errors:
   //
-  // * `NOT_FOUND`: At least one of the blob chunks is not present in the CAS.
+  // * `NOT_FOUND`: At least one of the blob chunks is not present in the CAS,
+  //   OR the request has an indirect_chunk_list which is not present in the
+  //   CAS.
   // * `RESOURCE_EXHAUSTED`: There is insufficient disk quota to store the
   //   spliced blob.
   // * `INVALID_ARGUMENT`: The digest of the spliced blob is different from the
-  //   provided expected digest.
+  //   provided expected digest, OR the request has an indirect_chunk_list to
+  //   which the chunks digests do not form a valid prefix.
   // * `ALREADY_EXISTS`: The blob already exists in CAS and the server did not
   //   extend the lifetime of the chunks specified in the request, e.g. because
   //   it prefers a different chunking and extended those instead. Clients can
@@ -1965,6 +1968,13 @@ message GetTreeResponse {
   string next_page_token = 2;
 }
 
+// A ChunkList is a list of chunks stored in the CAS. The Digest of a ChunkList
+// is computed over its protobuf wire format serialization.
+message ChunkList {
+  // An ordered list of chunk digests.
+  repeated Digest chunk_digests = 1;
+}
+
 // A request message for
 // [ContentAddressableStorage.SplitBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitBlob].
 message SplitBlobRequest {
@@ -1998,7 +2008,10 @@ message SplitBlobRequest {
 message SplitBlobResponse {
   // The ordered list of digests of the chunks into which the blob was split.
   // The original blob is assembled by concatenating the chunk data according to
-  // the order of the digests given by this list.
+  // the order of the digests given by this list. If the indirect_chunk_list is
+  // set this is instead a prefix of the indirect_chunk_list and the original
+  // blob is assembled by concatenating the chunk data expressed by the
+  // indirect_chunk_list.
   //
   // The server MUST use the same digest function as the one explicitly or
   // implicitly (through hash length) specified in the split request.
@@ -2006,6 +2019,13 @@ message SplitBlobResponse {
 
   // The chunking function used to split the blob.
   ChunkingFunction.Value chunking_function = 2;
+
+  // The digest of the indirect chunk list which MUST be present in the
+  // [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage].
+  // The server MAY set this field in addition to the chunk_digests field. If
+  // set the chunk_digests field MUST be a prefix of the indirect_chunk_list and
+  // the indirect_chunk_list represents the full list of chunks for the blob.
+  Digest indirect_chunk_list = 6;
 }
 
 // A request message for
@@ -2033,7 +2053,10 @@ message SpliceBlobRequest {
   Digest blob_digest = 2;
 
   // The ordered list of digests of the chunks which need to be concatenated to
-  // assemble the original blob.
+  // assemble the original blob. If the indirect_chunk_list is set this is
+  // instead a prefix of the indirect_chunk_list and the original blob is
+  // assembled by concatenating the chunk data expressed by the
+  // indirect_chunk_list.
   repeated Digest chunk_digests = 3;
 
   // The digest function of all chunks to be concatenated and of the blob to be
@@ -2047,6 +2070,12 @@ message SpliceBlobRequest {
 
   // The chunking function that the client used to split the blob.
   ChunkingFunction.Value chunking_function = 5;
+
+  // The digest of the indirect chunk list stored in the CAS. The client MAY set
+  // this field in addition to the chunk_digests field. If set the chunk_digests
+  // field MUST be a prefix of the indirect_chunk_list and the
+  // indirect_chunk_list represents the full list of chunks for the blob.
+  Digest indirect_chunk_list = 6;
 }
 
 // A response message for

--- a/build/bazel/remote/execution/v2/remote_execution_grpc.pb.go
+++ b/build/bazel/remote/execution/v2/remote_execution_grpc.pb.go
@@ -951,11 +951,14 @@ type ContentAddressableStorageClient interface {
 	//
 	// Errors:
 	//
-	//   - `NOT_FOUND`: At least one of the blob chunks is not present in the CAS.
+	//   - `NOT_FOUND`: At least one of the blob chunks is not present in the CAS,
+	//     OR the request has an indirect_chunk_list which is not present in the
+	//     CAS.
 	//   - `RESOURCE_EXHAUSTED`: There is insufficient disk quota to store the
 	//     spliced blob.
 	//   - `INVALID_ARGUMENT`: The digest of the spliced blob is different from the
-	//     provided expected digest.
+	//     provided expected digest, OR the request has an indirect_chunk_list to
+	//     which the chunks digests do not form a valid prefix.
 	//   - `ALREADY_EXISTS`: The blob already exists in CAS and the server did not
 	//     extend the lifetime of the chunks specified in the request, e.g. because
 	//     it prefers a different chunking and extended those instead. Clients can
@@ -1380,11 +1383,14 @@ type ContentAddressableStorageServer interface {
 	//
 	// Errors:
 	//
-	//   - `NOT_FOUND`: At least one of the blob chunks is not present in the CAS.
+	//   - `NOT_FOUND`: At least one of the blob chunks is not present in the CAS,
+	//     OR the request has an indirect_chunk_list which is not present in the
+	//     CAS.
 	//   - `RESOURCE_EXHAUSTED`: There is insufficient disk quota to store the
 	//     spliced blob.
 	//   - `INVALID_ARGUMENT`: The digest of the spliced blob is different from the
-	//     provided expected digest.
+	//     provided expected digest, OR the request has an indirect_chunk_list to
+	//     which the chunks digests do not form a valid prefix.
 	//   - `ALREADY_EXISTS`: The blob already exists in CAS and the server did not
 	//     extend the lifetime of the chunks specified in the request, e.g. because
 	//     it prefers a different chunking and extended those instead. Clients can


### PR DESCRIPTION
The split and splice api calls have an implicit maximum file size they can represent due to the maximum grpc message size. Remove this file size limit by adding an indirect_chunk_list field to the SplitBlobResponse and SpliceBlobRequest respectively.

This allows implementations to, in a backwards compatible manner, defer the list of chunks to an object stored in CAS making the split and splice blob requests capable of representing blobs of any size.